### PR TITLE
add python library to opencnpj

### DIFF
--- a/Page/index.html
+++ b/Page/index.html
@@ -241,6 +241,11 @@ curl -s "https://api.opencnpj.org/00.000.000/000000" | jq</pre>
                 <td>José Marinho</td>
                 <td><a href="https://github.com/jusemarinho/nestjs-opencnpj" target="_blank" rel="noopener">github.com/jusemarinho/nestjs-opencnpj</a></td>
               </tr>
+			  <tr>
+                <td>Python</td>
+                <td>Gabriel Oliva</td>
+                <td><a href="https://github.com/ofcoliva/opencnpj" target="_blank" rel="noopener">github.com/ofcoliva/opencnpj</a></td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
A biblioteca opencnpj para Python está no meu github e disponível para download no pypi.org, caso tenham interesse em contribuir basta fazer um pull request