### PR TITLE
docs(page): add consulta-cnpj-ws (Node.js) to libraries list

### DIFF
--- a/src/Page/src/data/libraries.ts
+++ b/src/Page/src/data/libraries.ts
@@ -48,4 +48,10 @@ export const libraries: Library[] = [
     repository: 'github.com/gustavogomesn/python-opencnpj',
     href: 'https://github.com/gustavogomesn/python-opencnpj',
   },
+  {
+    language: 'Node.js',
+    author: 'José Eduardo',
+    repository: 'github.com/jos3duardo/cnpj-ws',
+    href: 'https://github.com/jos3duardo/cnpj-ws',
+  },
 ];


### PR DESCRIPTION
## Resumo

Adiciona a biblioteca **consulta-cnpj-ws** (Node.js) à lista da página `/#/bibliotecas`.

- Linguagem: Node.js
- Autor: José Eduardo
- Repositório: https://github.com/jos3duardo/cnpj-ws
- NPM: https://www.npmjs.com/package/consulta-cnpj-ws

A biblioteca consome a API do OpenCNPJ (https://api.opencnpj.org/) e fornece uma forma simples de consultar CNPJs em aplicações Node.js.

## Mudança

Apenas uma entrada nova em `src/Page/src/data/libraries.ts`, seguindo o mesmo padrão das demais bibliotecas.
