### PR TITLE
[codex] publish columnar BigQuery tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,14 @@ RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
         | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/google-cloud.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
         > /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends nodejs google-cloud-cli \
     && npm install -g wrangler \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Projeto aberto para baixar, processar e publicar dados públicos das empresas do
 
 - `.NET SDK 10.0+`
 - `rclone` instalado e autenticado no seu storage (ex.: Backblaze, R2, S3, Azure Storage, ...).
+- `bq` instalado e autenticado somente quando `BigQuery.Enabled=true`.
 - Espaço em disco e boa conexão (a primeira execução pode levar tempo -- dias até).
 
 ## Configuração
@@ -22,12 +23,16 @@ Projeto aberto para baixar, processar e publicar dados públicos das empresas do
 - Ajuste `src/ETL/Processor/config.json` se desejar mudar pastas locais, destino do storage, memória, paralelismo...
 - No `config.json`, aponte para o Storage que deseja passando a configuração do rclone.
 - O downloader da Receita agora usa WebDAV no share público do SERPRO+/Nextcloud.
+- A publicação no BigQuery fica desligada por padrão. Com `BigQuery.Enabled=false` e sem override, o pipeline apenas emite um aviso e segue sem exigir `bq` ou credenciais Google.
+- Para habilitar BigQuery, configure `BigQuery.Enabled=true` ou `OPENCNPJ_BIGQUERY_ENABLED=true`, além de `Dataset`, `TablePrefix` opcional, `Location` opcional e `BqExecutable` se o binário não for `bq`. O projeto pode vir de `BigQuery.ProjectId` no `config.json` ou da env `OPENCNPJ_BIGQUERY_PROJECT_ID`; as envs têm prioridade. Em container, `OPENCNPJ_GOOGLE_CREDENTIALS_BASE64` pode receber a credencial Google codificada em base64 como secret do ambiente.
 
 ## Layout local
 
 - `downloads/YYYY-MM`: zips baixados da Receita.
 - `extracted_data/YYYY-MM`: arquivos extraídos para o mês.
 - `parquet_data/YYYY-MM`: Parquets gerados para o mês e Parquets mais recentes das integrações.
+- `parquet_data/YYYY-MM/bigquery/receita/part-*.parquet`: Parquets colunares da Receita para BigQuery, com 1 linha por CNPJ.
+- `parquet_data/YYYY-MM/integrations/{cno,rntrc}/bigquery/*.parquet`: Parquets colunares das integrações para BigQuery.
 - `cnpj_shards/YYYY-MM/releases/{release_id}/shards`: shards locais `*.ndjson` e `*.index.bin` do release atual.
 
 Os artefatos locais não são apagados automaticamente, exceto quando o pipeline é executado com `--cleanup-on-success`. Nesse modo, o cleanup remove downloads, CSVs extraídos e temporários, mas preserva Parquets e releases locais para permitir recomposição incremental.
@@ -37,7 +42,8 @@ Os artefatos locais não são apagados automaticamente, exceto quando o pipeline
 - O ETL possui a interface interna `IDataIntegration` para sub-módulos de dados.
 - Cada integração declara chave, propriedade JSON, frequência de atualização e versão de schema.
 - O estado de hashes por CNPJ de cada integração é publicado via rclone em `files/integrations/state/{module}/hashes.json`.
-- Integrações devem gerar Parquet com 1 linha por CNPJ (`cnpj`, `cnpj_prefix`, `payload_json`, `content_hash`, datas de origem/módulo).
+- Integrações devem gerar Parquet canônico com 1 linha por CNPJ (`cnpj`, `cnpj_prefix`, `payload_json`, `content_hash`, datas de origem/módulo) para API, shards e cálculo incremental.
+- Quando publicadas no BigQuery, as integrações com suporte dedicado geram um Parquet columnar separado, sem `payload_json`.
 - O JSON final sempre inclui a chave das integrações habilitadas; quando o CNPJ não tiver dado naquela integração, o valor fica `null`.
 
 ## Execução
@@ -49,6 +55,12 @@ Os artefatos locais não são apagados automaticamente, exceto quando o pipeline
   - `dotnet run pipeline --cleanup-on-success` (opcional, remove artefatos locais do dataset após sucesso)
 
 Sem `-m`, o pipeline escolhe o mês mais recente publicado no share WebDAV da Receita.
+
+Quando `BigQuery.Enabled=true`, o pipeline carrega 1 tabela por módulo: `receita`, `cno`, `rntrc` e futuras integrações que publiquem um Parquet canônico. `receita`, `cno` e `rntrc` são carregadas a partir de Parquets colunares, sem `payload_json`. A carga acontece após shards/ZIPs serem gerados e antes do `info.json` e do estado de integração serem publicados, para falhar o release antes de marcá-lo como concluído.
+
+Antes de carregar tabelas, o deploy e o ETL executam uma validação via `bq show {ProjectId}:{Dataset}`. O BigQuery pode ser ligado por `OPENCNPJ_BIGQUERY_ENABLED=true`, e o `ProjectId` vem de `OPENCNPJ_BIGQUERY_PROJECT_ID` ou do `config.json`. O projeto é passado explicitamente em todos os comandos BigQuery, então o fluxo não depende do projeto default configurado no `gcloud`. O dataset precisa existir; as tabelas finais podem existir ou não. Cada execução carrega uma tabela staging a partir do Parquet columnar e substitui/cria a tabela final com `bq cp --force`, permitindo atualizar schemas desatualizados, como a tabela `receita`, e criar tabelas novas, como `cno` e `rntrc`.
+
+Para deploy em container com credencial via env, gere o valor com `base64 -w 0 arquivo.json` e configure `OPENCNPJ_GOOGLE_CREDENTIALS_BASE64` como secret. O entrypoint decodifica a credencial em arquivo temporário, ativa `gcloud auth activate-service-account` e remove o arquivo antes de iniciar o deploy.
 
 ### Página estática
 
@@ -72,6 +84,8 @@ A página é implementada em React + TypeScript e continua sendo 100% estática 
 
 - Use `src/script/deploy.sh` para orquestrar o release:
   - roda o ETL com release versionado
+  - ignora BigQuery com aviso quando `BigQuery.Enabled=false`
+  - valida `OPENCNPJ_BIGQUERY_ENABLED` ou `BigQuery.Enabled`, `OPENCNPJ_BIGQUERY_PROJECT_ID` ou `BigQuery.ProjectId`, `BigQuery.Dataset`, o comando `bq` configurado e o acesso ao dataset quando BigQuery está habilitado
   - copia `info.json` e `*.index.bin` do release gerado para `src/Worker/assets`
   - executa `npm test` no Worker
   - faz `npx wrangler deploy`

--- a/src/ETL/Integrations.Abstractions/Models/BigQueryParquetSource.cs
+++ b/src/ETL/Integrations.Abstractions/Models/BigQueryParquetSource.cs
@@ -1,0 +1,5 @@
+namespace CNPJExporter.Integrations;
+
+public sealed record BigQueryParquetSource(
+    string TableName,
+    IReadOnlyList<string> SourcePaths);

--- a/src/ETL/Modules/Cno/BigQueryParquetExporter.cs
+++ b/src/ETL/Modules/Cno/BigQueryParquetExporter.cs
@@ -1,0 +1,89 @@
+using CNPJExporter.Integrations;
+using DuckDB.NET.Data;
+using Spectre.Console;
+
+namespace CNPJExporter.Modules.Cno;
+
+public sealed class BigQueryParquetExporter
+{
+    public const string TableName = "cno";
+
+    private const string ObrasJsonSchema = """[{"cno":"VARCHAR","nome":"VARCHAR","nome_empresarial":"VARCHAR","situacao":{"codigo":"VARCHAR","descricao":"VARCHAR"},"data_inicio":"VARCHAR","data_inicio_responsabilidade":"VARCHAR","data_registro":"VARCHAR","data_situacao":"VARCHAR","cep":"VARCHAR","uf":"VARCHAR","codigo_municipio":"VARCHAR","municipio":"VARCHAR","tipo_logradouro":"VARCHAR","logradouro":"VARCHAR","numero":"VARCHAR","bairro":"VARCHAR","complemento":"VARCHAR","unidade_medida":"VARCHAR","area_total":"VARCHAR","cno_vinculado":"VARCHAR","codigo_pais":"VARCHAR","pais":"VARCHAR","qualificacao_responsavel":{"codigo":"VARCHAR","descricao":"VARCHAR"},"codigo_localizacao":"VARCHAR"}]""";
+
+    private readonly string _sourceParquetPath;
+
+    public BigQueryParquetExporter(string sourceParquetPath)
+    {
+        _sourceParquetPath = sourceParquetPath;
+    }
+
+    public async Task<BigQueryParquetSource> MaterializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_sourceParquetPath))
+            throw new FileNotFoundException("Parquet canônico do CNO não encontrado.", _sourceParquetPath);
+
+        var outputPath = GetOutputPath(_sourceParquetPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        DeleteIfExists(outputPath);
+
+        await using var connection = new DuckDBConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await ConfigureAsync(connection, outputPath, cancellationToken);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $@"
+            COPY (
+                SELECT
+                    cnpj,
+                    TRY_CAST(cnpj_prefix AS INTEGER) AS cnpj_prefix,
+                    json_extract_string(payload_json, '$.updated_at') AS updated_at,
+                    from_json(json_extract(payload_json, '$.obras'), '{EscapeSqlLiteral(ObrasJsonSchema)}') AS obras
+                FROM read_parquet('{EscapeSqlLiteral(_sourceParquetPath)}')
+            )
+            TO '{EscapeSqlLiteral(outputPath)}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, OVERWRITE)";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+        AnsiConsole.MarkupLine($"[grey]BigQuery CNO:[/] Parquet columnar gerado em [grey]{outputPath.EscapeMarkup()}[/]");
+        return GetSource(_sourceParquetPath);
+    }
+
+    public static BigQueryParquetSource GetSource(string sourceParquetPath)
+    {
+        var outputPath = GetOutputPath(sourceParquetPath);
+        IReadOnlyList<string> sourcePaths = File.Exists(outputPath)
+            ? [outputPath]
+            : Array.Empty<string>();
+
+        return new BigQueryParquetSource(TableName, sourcePaths);
+    }
+
+    private static string GetOutputPath(string sourceParquetPath) =>
+        Path.Combine(Path.GetDirectoryName(sourceParquetPath)!, "bigquery", $"{TableName}.parquet");
+
+    private static async Task ConfigureAsync(
+        DuckDBConnection connection,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(Path.GetDirectoryName(outputPath)!, "_duckdb_temp");
+        Directory.CreateDirectory(tempDir);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $@"
+            SET threads = 4;
+            SET memory_limit = '8GB';
+            SET preserve_insertion_order = false;
+            SET temp_directory = '{EscapeSqlLiteral(tempDir)}';
+            SET max_temp_directory_size = '200GB';";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/ETL/Modules/Cno/Processors/ParquetProcessor.cs
+++ b/src/ETL/Modules/Cno/Processors/ParquetProcessor.cs
@@ -315,7 +315,7 @@ public sealed class ParquetProcessor
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = $@"
             SET preserve_insertion_order = false;
-            SET threads = 1;
+            SET threads = 4;
             SET memory_limit = '8GB';
             SET temp_directory = '{EscapeSqlLiteral(tempDir)}';
             SET max_temp_directory_size = '200GB';";

--- a/src/ETL/Modules/Receita/BigQueryParquetExporter.cs
+++ b/src/ETL/Modules/Receita/BigQueryParquetExporter.cs
@@ -1,0 +1,114 @@
+using CNPJExporter.Integrations;
+using CNPJExporter.Modules.Receita.Processors;
+using DuckDB.NET.Data;
+using Spectre.Console;
+
+namespace CNPJExporter.Modules.Receita;
+
+public sealed class BigQueryParquetExporter
+{
+    public const string TableName = "receita";
+
+    private const int DefaultPrefixBatchSize = 10;
+
+    private readonly string _parquetRoot;
+    private readonly int _shardPrefixLength;
+
+    public BigQueryParquetExporter(string parquetRoot, int shardPrefixLength)
+    {
+        _parquetRoot = parquetRoot;
+        _shardPrefixLength = Math.Max(1, shardPrefixLength);
+    }
+
+    public async Task<IReadOnlyList<string>> MaterializeAsync(
+        string datasetKey,
+        CancellationToken cancellationToken = default)
+    {
+        var outputDir = GetPartsDirectory(_parquetRoot);
+        if (Directory.Exists(outputDir))
+            Directory.Delete(outputDir, recursive: true);
+
+        Directory.CreateDirectory(outputDir);
+
+        var shardQueryBuilder = new ShardQueryBuilder(_parquetRoot);
+        var prefixes = shardQueryBuilder.GetExistingShardPrefixes();
+        if (prefixes.Count == 0)
+            throw new InvalidOperationException("Nenhuma partição da Receita encontrada para materializar o BigQuery.");
+
+        await using var connection = new DuckDBConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await ConfigureAsync(connection, outputDir, cancellationToken);
+
+        var parquetProcessor = new ParquetProcessor(
+            dataDir: string.Empty,
+            parquetDir: _parquetRoot,
+            shardPrefixLength: _shardPrefixLength);
+        await parquetProcessor.LoadTablesForConnectionAsync(
+            connection,
+            includeShardTables: false,
+            showWarnings: false);
+
+        AnsiConsole.MarkupLine(
+            $"[grey]BigQuery Receita:[/] materializando {prefixes.Count} prefixos em partes colunares");
+
+        var outputPaths = new List<string>();
+        for (var offset = 0; offset < prefixes.Count; offset += DefaultPrefixBatchSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var batch = prefixes.Skip(offset).Take(DefaultPrefixBatchSize).ToArray();
+            var outputPath = Path.Combine(outputDir, $"part-{offset / DefaultPrefixBatchSize:00000}.parquet");
+
+            var columnarQuery = shardQueryBuilder.BuildColumnarQueryForPrefixBatch(batch);
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+                COPY (
+                    {columnarQuery}
+                )
+                TO '{EscapeSqlLiteral(outputPath)}'
+                (FORMAT PARQUET, COMPRESSION ZSTD, OVERWRITE)";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+            outputPaths.Add(outputPath);
+            AnsiConsole.MarkupLine(
+                $"[grey]BigQuery Receita:[/] parte {outputPaths.Count} gerada [grey]({batch.First().EscapeMarkup()}..{batch.Last().EscapeMarkup()})[/]");
+        }
+
+        return outputPaths;
+    }
+
+    public static BigQueryParquetSource GetSource(string parquetRoot)
+    {
+        var partsDir = GetPartsDirectory(parquetRoot);
+        IReadOnlyList<string> sourcePaths = Directory.Exists(partsDir)
+            ? Directory
+                .EnumerateFiles(partsDir, "part-*.parquet", SearchOption.TopDirectoryOnly)
+                .Order(StringComparer.Ordinal)
+                .ToArray()
+            : Array.Empty<string>();
+
+        return new BigQueryParquetSource(TableName, sourcePaths);
+    }
+
+    public static string GetPartsDirectory(string parquetRoot) =>
+        Path.Combine(parquetRoot, "bigquery", TableName);
+
+    private static async Task ConfigureAsync(
+        DuckDBConnection connection,
+        string outputDir,
+        CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(outputDir, "_duckdb_temp");
+        Directory.CreateDirectory(tempDir);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $@"
+            SET threads = 4;
+            SET memory_limit = '8GB';
+            SET preserve_insertion_order = false;
+            SET temp_directory = '{EscapeSqlLiteral(tempDir)}';
+            SET max_temp_directory_size = '200GB';";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/ETL/Modules/Receita/Processors/ShardQueryBuilder.cs
+++ b/src/ETL/Modules/Receita/Processors/ShardQueryBuilder.cs
@@ -125,6 +125,201 @@ public sealed class ShardQueryBuilder
 	            LEFT JOIN batch_socios sd ON e.cnpj_prefix = sd.cnpj_prefix AND e.cnpj_basico = sd.cnpj_basico";
     }
 
+    public string BuildColumnarQueryForPrefixBatch(IReadOnlyList<string> prefixes)
+    {
+        var estabelecimentoRelation = BuildPartitionedReadSql("estabelecimento", prefixes, allowEmpty: false);
+        var empresaRelation = BuildPartitionedReadSql("empresa", prefixes, allowEmpty: false);
+        var simplesRelation = BuildPartitionedReadSql("simples", prefixes, allowEmpty: true);
+
+        return $@"WITH batch_estabelecimentos AS (
+                SELECT * FROM {estabelecimentoRelation}
+            ),
+            batch_empresas AS (
+                SELECT * FROM {empresaRelation}
+            ),
+	            batch_simples AS (
+	                SELECT * FROM {simplesRelation}
+	            ),
+	            cnae_lookup AS (
+	                SELECT map_from_entries(array_agg(struct_pack(key := codigo, value := descricao))) AS descricoes
+	                FROM cnae
+	            ),
+	            {BuildQsaCte("batch_socios", prefixes)}
+	            SELECT
+                    e.cnpj_basico || e.cnpj_ordem || e.cnpj_dv AS cnpj,
+                    TRY_CAST(e.cnpj_prefix AS INTEGER) AS cnpj_prefix,
+                    COALESCE(emp.razao_social, '') AS razao_social,
+                    COALESCE(e.nome_fantasia, '') AS nome_fantasia,
+                    CASE LPAD(e.situacao_cadastral, 2, '0')
+                        WHEN '01' THEN 'Nula'
+                        WHEN '02' THEN 'Ativa'
+                        WHEN '03' THEN 'Suspensa'
+                        WHEN '04' THEN 'Inapta'
+                        WHEN '08' THEN 'Baixada'
+                        ELSE COALESCE(e.situacao_cadastral, '')
+                    END AS situacao_cadastral,
+                    CASE
+                        WHEN e.data_situacao_cadastral ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(e.data_situacao_cadastral, 1, 4) || '-' ||
+                                      SUBSTRING(e.data_situacao_cadastral, 5, 2) || '-' ||
+                                      SUBSTRING(e.data_situacao_cadastral, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(e.data_situacao_cadastral, '') AS DATE)
+                    END AS data_situacao_cadastral,
+                    CASE e.identificador_matriz_filial
+                        WHEN '1' THEN 'Matriz'
+                        WHEN '2' THEN 'Filial'
+                        ELSE COALESCE(e.identificador_matriz_filial, '')
+                    END AS matriz_filial,
+                    CASE
+                        WHEN e.data_inicio_atividade ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(e.data_inicio_atividade, 1, 4) || '-' ||
+                                      SUBSTRING(e.data_inicio_atividade, 5, 2) || '-' ||
+                                      SUBSTRING(e.data_inicio_atividade, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(e.data_inicio_atividade, '') AS DATE)
+                    END AS data_inicio_atividade,
+                    COALESCE(e.cnae_principal, '') AS cnae_principal,
+                    CASE
+                        WHEN e.cnaes_secundarios IS NOT NULL AND e.cnaes_secundarios != ''
+                        THEN string_split(e.cnaes_secundarios, ',')
+                        ELSE []
+                    END AS cnaes_secundarios,
+                    list_transform(
+                        list_filter(
+                            list_concat(
+                                [COALESCE(e.cnae_principal, '')],
+                                CASE
+                                    WHEN e.cnaes_secundarios IS NOT NULL AND e.cnaes_secundarios != ''
+                                    THEN string_split(e.cnaes_secundarios, ',')
+                                    ELSE []
+                                END),
+                            codigo -> codigo != ''),
+                        codigo -> struct_pack(
+                            codigo := codigo,
+                            descricao := COALESCE(map_extract_value(cnae_lookup.descricoes, codigo), ''),
+                            is_principal := codigo = COALESCE(e.cnae_principal, '')
+                        )) AS cnaes,
+                    COALESCE(nat.descricao, '') AS natureza_juridica,
+                    COALESCE(e.tipo_logradouro, '') AS tipo_logradouro,
+                    COALESCE(e.logradouro, '') AS logradouro,
+                    COALESCE(e.numero, '') AS numero,
+                    COALESCE(e.complemento, '') AS complemento,
+                    COALESCE(e.bairro, '') AS bairro,
+                    COALESCE(e.cep, '') AS cep,
+                    COALESCE(e.uf, '') AS uf,
+                    COALESCE(mun.descricao, '') AS municipio,
+                    COALESCE(e.codigo_municipio, '') AS codigo_municipio,
+                    COALESCE(e.correio_eletronico, '') AS email,
+                    list_filter([
+                        CASE WHEN e.ddd1 IS NOT NULL OR e.telefone1 IS NOT NULL
+                             THEN struct_pack(ddd := COALESCE(e.ddd1, ''), numero := COALESCE(e.telefone1, ''), is_fax := false)
+                             ELSE NULL
+                        END,
+                        CASE WHEN e.ddd2 IS NOT NULL OR e.telefone2 IS NOT NULL
+                             THEN struct_pack(ddd := COALESCE(e.ddd2, ''), numero := COALESCE(e.telefone2, ''), is_fax := false)
+                             ELSE NULL
+                        END,
+                        CASE WHEN e.ddd_fax IS NOT NULL OR e.fax IS NOT NULL
+                             THEN struct_pack(ddd := COALESCE(e.ddd_fax, ''), numero := COALESCE(e.fax, ''), is_fax := true)
+                             ELSE NULL
+                        END
+                    ], telefone -> telefone IS NOT NULL) AS telefones,
+                    TRY_CAST(REPLACE(NULLIF(emp.capital_social, ''), ',', '.') AS DECIMAL(18, 2)) AS capital_social,
+                    struct_pack(
+                        codigo := COALESCE(emp.qualificacao_responsavel, ''),
+                        descricao := COALESCE(qr.descricao, '')
+                    ) AS qualificacao_responsavel,
+                    COALESCE(emp.ente_federativo, '') AS ente_federativo,
+                    CASE emp.porte_empresa
+                        WHEN '00' THEN 'Não informado'
+                        WHEN '01' THEN 'Microempresa (ME)'
+                        WHEN '03' THEN 'Empresa de Pequeno Porte (EPP)'
+                        WHEN '05' THEN 'Demais'
+                        ELSE COALESCE(emp.porte_empresa, '')
+                    END AS porte_empresa,
+                    CASE
+                        WHEN UPPER(COALESCE(s.opcao_simples, '')) = 'S' THEN true
+                        WHEN UPPER(COALESCE(s.opcao_simples, '')) = 'N' THEN false
+                        ELSE NULL
+                    END AS opcao_simples,
+                    CASE
+                        WHEN s.data_opcao_simples ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(s.data_opcao_simples, 1, 4) || '-' ||
+                                      SUBSTRING(s.data_opcao_simples, 5, 2) || '-' ||
+                                      SUBSTRING(s.data_opcao_simples, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(s.data_opcao_simples, '') AS DATE)
+                    END AS data_opcao_simples,
+                    CASE
+                        WHEN s.data_exclusao_simples ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(s.data_exclusao_simples, 1, 4) || '-' ||
+                                      SUBSTRING(s.data_exclusao_simples, 5, 2) || '-' ||
+                                      SUBSTRING(s.data_exclusao_simples, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(s.data_exclusao_simples, '') AS DATE)
+                    END AS data_exclusao_simples,
+                    CASE
+                        WHEN UPPER(COALESCE(s.opcao_mei, '')) = 'S' THEN true
+                        WHEN UPPER(COALESCE(s.opcao_mei, '')) = 'N' THEN false
+                        ELSE NULL
+                    END AS opcao_mei,
+                    CASE
+                        WHEN s.data_opcao_mei ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(s.data_opcao_mei, 1, 4) || '-' ||
+                                      SUBSTRING(s.data_opcao_mei, 5, 2) || '-' ||
+                                      SUBSTRING(s.data_opcao_mei, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(s.data_opcao_mei, '') AS DATE)
+                    END AS data_opcao_mei,
+                    CASE
+                        WHEN s.data_exclusao_mei ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(s.data_exclusao_mei, 1, 4) || '-' ||
+                                      SUBSTRING(s.data_exclusao_mei, 5, 2) || '-' ||
+                                      SUBSTRING(s.data_exclusao_mei, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(s.data_exclusao_mei, '') AS DATE)
+                    END AS data_exclusao_mei,
+                    struct_pack(
+                        codigo := COALESCE(e.motivo_situacao_cadastral, ''),
+                        descricao := COALESCE(mot.descricao, '')
+                    ) AS motivo_situacao_cadastral,
+                    COALESCE(e.nome_cidade_exterior, '') AS nome_cidade_exterior,
+                    COALESCE(e.codigo_pais, '') AS codigo_pais,
+                    struct_pack(
+                        codigo := COALESCE(e.codigo_pais, ''),
+                        descricao := COALESCE(pais_est.descricao, '')
+                    ) AS pais,
+                    COALESCE(e.situacao_especial, '') AS situacao_especial,
+                    CASE
+                        WHEN e.data_situacao_especial ~ '^[0-9]{{8}}$'
+                        THEN TRY_CAST(SUBSTRING(e.data_situacao_especial, 1, 4) || '-' ||
+                                      SUBSTRING(e.data_situacao_especial, 5, 2) || '-' ||
+                                      SUBSTRING(e.data_situacao_especial, 7, 2) AS DATE)
+                        ELSE TRY_CAST(NULLIF(e.data_situacao_especial, '') AS DATE)
+                    END AS data_situacao_especial,
+                    COALESCE(
+                        list_transform(sd.qsa_data, socio -> struct_pack(
+                            nome_socio := socio.nome_socio,
+                            cnpj_cpf_socio := socio.cnpj_cpf_socio,
+                            qualificacao_socio := socio.qualificacao_socio,
+                            data_entrada_sociedade := TRY_CAST(NULLIF(socio.data_entrada_sociedade, '') AS DATE),
+                            identificador_socio := socio.identificador_socio,
+                            codigo_pais := socio.codigo_pais,
+                            pais := socio.pais,
+                            representante_legal := socio.representante_legal,
+                            nome_representante := socio.nome_representante,
+                            qualificacao_representante := socio.qualificacao_representante,
+                            faixa_etaria := socio.faixa_etaria
+                        )),
+                        []
+                    ) AS QSA
+	            FROM batch_estabelecimentos e
+	            CROSS JOIN cnae_lookup
+	            LEFT JOIN batch_empresas emp ON e.cnpj_basico = emp.cnpj_basico
+	            LEFT JOIN batch_simples s ON e.cnpj_basico = s.cnpj_basico
+	            LEFT JOIN natureza nat ON emp.natureza_juridica = nat.codigo
+	            LEFT JOIN municipio mun ON e.codigo_municipio = mun.codigo
+	            LEFT JOIN motivo mot ON e.motivo_situacao_cadastral = mot.codigo
+	            LEFT JOIN pais pais_est ON e.codigo_pais = pais_est.codigo
+	            LEFT JOIN qualificacao qr ON emp.qualificacao_responsavel = qr.codigo
+	            LEFT JOIN batch_socios sd ON e.cnpj_prefix = sd.cnpj_prefix AND e.cnpj_basico = sd.cnpj_basico";
+    }
+
     public string BuildJsonQueryForCnpj(
         string prefix,
         string cnpjBasico,

--- a/src/ETL/Modules/Rntrc/BigQueryParquetExporter.cs
+++ b/src/ETL/Modules/Rntrc/BigQueryParquetExporter.cs
@@ -1,0 +1,96 @@
+using CNPJExporter.Integrations;
+using DuckDB.NET.Data;
+using Spectre.Console;
+
+namespace CNPJExporter.Modules.Rntrc;
+
+public sealed class BigQueryParquetExporter
+{
+    public const string TableName = "rntrc";
+
+    private readonly string _sourceParquetPath;
+
+    public BigQueryParquetExporter(string sourceParquetPath)
+    {
+        _sourceParquetPath = sourceParquetPath;
+    }
+
+    public async Task<BigQueryParquetSource> MaterializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_sourceParquetPath))
+            throw new FileNotFoundException("Parquet canônico do RNTRC não encontrado.", _sourceParquetPath);
+
+        var outputPath = GetOutputPath(_sourceParquetPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        DeleteIfExists(outputPath);
+
+        await using var connection = new DuckDBConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await ConfigureAsync(connection, outputPath, cancellationToken);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $@"
+            COPY (
+                SELECT
+                    cnpj,
+                    TRY_CAST(cnpj_prefix AS INTEGER) AS cnpj_prefix,
+                    json_extract_string(payload_json, '$.updated_at') AS updated_at,
+                    json_extract_string(payload_json, '$.numero_rntrc') AS numero_rntrc,
+                    json_extract_string(payload_json, '$.nome') AS nome,
+                    json_extract_string(payload_json, '$.categoria') AS categoria,
+                    json_extract_string(payload_json, '$.situacao') AS situacao,
+                    json_extract_string(payload_json, '$.data_primeiro_cadastro') AS data_primeiro_cadastro,
+                    json_extract_string(payload_json, '$.data_situacao') AS data_situacao,
+                    json_extract_string(payload_json, '$.cep') AS cep,
+                    json_extract_string(payload_json, '$.municipio') AS municipio,
+                    json_extract_string(payload_json, '$.uf') AS uf,
+                    TRY_CAST(json_extract_string(payload_json, '$.equiparado') AS BOOLEAN) AS equiparado
+                FROM read_parquet('{EscapeSqlLiteral(_sourceParquetPath)}')
+            )
+            TO '{EscapeSqlLiteral(outputPath)}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, OVERWRITE)";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+        AnsiConsole.MarkupLine($"[grey]BigQuery RNTRC:[/] Parquet columnar gerado em [grey]{outputPath.EscapeMarkup()}[/]");
+        return GetSource(_sourceParquetPath);
+    }
+
+    public static BigQueryParquetSource GetSource(string sourceParquetPath)
+    {
+        var outputPath = GetOutputPath(sourceParquetPath);
+        IReadOnlyList<string> sourcePaths = File.Exists(outputPath)
+            ? [outputPath]
+            : Array.Empty<string>();
+
+        return new BigQueryParquetSource(TableName, sourcePaths);
+    }
+
+    private static string GetOutputPath(string sourceParquetPath) =>
+        Path.Combine(Path.GetDirectoryName(sourceParquetPath)!, "bigquery", $"{TableName}.parquet");
+
+    private static async Task ConfigureAsync(
+        DuckDBConnection connection,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        var tempDir = Path.Combine(Path.GetDirectoryName(outputPath)!, "_duckdb_temp");
+        Directory.CreateDirectory(tempDir);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $@"
+            SET threads = 4;
+            SET memory_limit = '8GB';
+            SET preserve_insertion_order = false;
+            SET temp_directory = '{EscapeSqlLiteral(tempDir)}';
+            SET max_temp_directory_size = '200GB';";
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/ETL/Modules/Rntrc/Processors/ParquetProcessor.cs
+++ b/src/ETL/Modules/Rntrc/Processors/ParquetProcessor.cs
@@ -214,7 +214,7 @@ public sealed class ParquetProcessor
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = $@"
             SET preserve_insertion_order = false;
-            SET threads = 1;
+            SET threads = 4;
             SET memory_limit = '8GB';
             SET temp_directory = '{EscapeSqlLiteral(tempDir)}';
             SET max_temp_directory_size = '200GB';";

--- a/src/ETL/Processor/BigQuery/BigQueryPublicationPlanner.cs
+++ b/src/ETL/Processor/BigQuery/BigQueryPublicationPlanner.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+using CNPJExporter.Configuration;
+using CNPJExporter.Integrations;
+
+namespace CNPJExporter.Processors.BigQuery;
+
+internal static class BigQueryPublicationPlanner
+{
+    private static readonly Regex BigQueryIdentifierPattern = new(
+        "^[A-Za-z_][A-Za-z0-9_]*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static BigQueryPublicationPlan Build(
+        AppConfig.BigQuerySettings settings,
+        string releaseId,
+        IReadOnlyList<BigQueryParquetSource> sources)
+    {
+        if (!settings.Enabled)
+            throw new InvalidOperationException("BigQuery.Enabled=false; o pipeline deve ignorar a publicação BigQuery em vez de montar um plano.");
+
+        var projectId = RequireValue(settings.ProjectId, "BigQuery.ProjectId");
+        var dataset = RequireIdentifier(settings.Dataset, "BigQuery.Dataset");
+        var tablePrefix = settings.TablePrefix?.Trim() ?? string.Empty;
+        if (tablePrefix.Length > 0 && !BigQueryIdentifierPattern.IsMatch(tablePrefix))
+            throw new InvalidOperationException("BigQuery.TablePrefix deve ser vazio ou um identificador ASCII simples.");
+
+        var normalizedReleaseId = RequireValue(releaseId, "releaseId");
+        var tables = sources
+            .Select(source => BuildTablePublication(source, tablePrefix))
+            .ToArray();
+
+        return new BigQueryPublicationPlan(
+            ProjectId: projectId,
+            Dataset: dataset,
+            ReleaseId: normalizedReleaseId,
+            BqExecutable: string.IsNullOrWhiteSpace(settings.BqExecutable) ? "bq" : settings.BqExecutable.Trim(),
+            Location: string.IsNullOrWhiteSpace(settings.Location) ? null : settings.Location.Trim(),
+            KeepStagingTables: settings.KeepStagingTables,
+            Tables: tables);
+    }
+
+    private static BigQueryTablePublication BuildTablePublication(
+        BigQueryParquetSource source,
+        string tablePrefix)
+    {
+        var tableName = RequireIdentifier(source.TableName, "BigQuery source table name");
+        var sourcePaths = RequireSourcePaths(tableName, source.SourcePaths);
+
+        return new BigQueryTablePublication(
+            tableName,
+            BuildDestinationTableName(tablePrefix, tableName),
+            sourcePaths);
+    }
+
+    private static string BuildDestinationTableName(string tablePrefix, string sourceName)
+    {
+        var tableName = $"{tablePrefix}{sourceName}";
+        if (!BigQueryIdentifierPattern.IsMatch(tableName))
+            throw new InvalidOperationException($"Tabela BigQuery inválida: {tableName}.");
+
+        return tableName;
+    }
+
+    private static string RequireValue(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"{name} é obrigatório quando BigQuery.Enabled=true.");
+
+        return value.Trim();
+    }
+
+    private static string RequireIdentifier(string? value, string name)
+    {
+        var normalized = RequireValue(value, name);
+        if (!BigQueryIdentifierPattern.IsMatch(normalized))
+            throw new InvalidOperationException($"{name} deve ser um identificador ASCII simples.");
+
+        return normalized;
+    }
+
+    private static IReadOnlyList<string> RequireSourcePaths(
+        string tableName,
+        IReadOnlyList<string> sourcePaths)
+    {
+        if (sourcePaths.Count == 0)
+            throw new InvalidOperationException($"Tabela BigQuery {tableName} não possui arquivos Parquet para publicação.");
+
+        return sourcePaths
+            .Select((sourcePath, index) =>
+            {
+                var normalized = RequireValue(sourcePath, $"BigQuery source path {index + 1} for {tableName}");
+                if (!File.Exists(normalized))
+                    throw new FileNotFoundException($"Parquet da tabela BigQuery {tableName} não encontrado em {normalized}.", normalized);
+
+                return normalized;
+            })
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+internal sealed record BigQueryPublicationPlan(
+    string ProjectId,
+    string Dataset,
+    string ReleaseId,
+    string BqExecutable,
+    string? Location,
+    bool KeepStagingTables,
+    IReadOnlyList<BigQueryTablePublication> Tables);
+
+internal sealed record BigQueryTablePublication(
+    string SourceName,
+    string DestinationTableName,
+    IReadOnlyList<string> SourcePaths);

--- a/src/ETL/Processor/BigQuery/BigQueryPublisher.cs
+++ b/src/ETL/Processor/BigQuery/BigQueryPublisher.cs
@@ -1,0 +1,157 @@
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace CNPJExporter.Processors.BigQuery;
+
+internal sealed class BigQueryPublisher
+{
+    private static readonly Regex InvalidTableNameCharacterPattern = new("[^A-Za-z0-9_]", RegexOptions.Compiled);
+    private readonly IBigQueryCommandRunner _commandRunner;
+
+    public BigQueryPublisher(IBigQueryCommandRunner? commandRunner = null)
+    {
+        _commandRunner = commandRunner ?? new ProcessBigQueryCommandRunner();
+    }
+
+    public async Task PublishAsync(
+        BigQueryPublicationPlan plan,
+        CancellationToken cancellationToken = default)
+    {
+        if (plan.Tables.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[yellow]BigQuery habilitado, mas nenhuma tabela foi selecionada para publicação.[/]");
+            return;
+        }
+
+        AnsiConsole.MarkupLine(
+            $"[cyan]Atualizando BigQuery[/] [grey](dataset: {plan.Dataset.EscapeMarkup()}, tabelas: {plan.Tables.Count})[/]");
+
+        var preparedTables = new List<PreparedBigQueryTable>(plan.Tables.Count);
+        foreach (var table in plan.Tables)
+        {
+            if (table.SourcePaths.Count == 0)
+                throw new InvalidOperationException($"Tabela BigQuery {table.SourceName} não possui arquivos Parquet para publicação.");
+
+            foreach (var sourcePath in table.SourcePaths)
+            {
+                if (!File.Exists(sourcePath))
+                    throw new FileNotFoundException($"Arquivo Parquet para BigQuery não encontrado: {sourcePath}.", sourcePath);
+            }
+
+            preparedTables.Add(new PreparedBigQueryTable(
+                table,
+                BuildStagingTableName(table.DestinationTableName, plan.ReleaseId)));
+        }
+
+        await ValidateTargetDatasetAsync(plan, cancellationToken);
+
+        foreach (var table in preparedTables)
+        {
+            AnsiConsole.MarkupLine(
+                $"[grey]BigQuery:[/] carregando staging [cyan]{table.StagingTableName.EscapeMarkup()}[/] [grey]({table.Source.SourcePaths.Count} parte(s))[/]");
+
+            for (var index = 0; index < table.Source.SourcePaths.Count; index++)
+            {
+                var sourcePath = table.Source.SourcePaths[index];
+                var loadArguments = new List<string>
+                {
+                    "load"
+                };
+                if (index == 0)
+                    loadArguments.Add("--replace");
+
+                loadArguments.Add("--source_format=PARQUET");
+                loadArguments.Add(FormatTableSpec(plan, table.StagingTableName));
+                loadArguments.Add(sourcePath);
+
+                AnsiConsole.MarkupLine(
+                    $"[grey]BigQuery:[/] parte {index + 1}/{table.Source.SourcePaths.Count} [grey]{Path.GetFileName(sourcePath).EscapeMarkup()}[/]");
+                await RunBqAsync(plan, loadArguments, cancellationToken);
+            }
+        }
+
+        foreach (var table in preparedTables)
+        {
+            AnsiConsole.MarkupLine(
+                $"[grey]BigQuery:[/] substituindo tabela final [cyan]{table.Source.DestinationTableName.EscapeMarkup()}[/]");
+            await RunBqAsync(
+                plan,
+                [
+                    "cp",
+                    "--force",
+                    FormatTableSpec(plan, table.StagingTableName),
+                    FormatTableSpec(plan, table.Source.DestinationTableName)
+                ],
+                cancellationToken);
+        }
+
+        if (!plan.KeepStagingTables)
+        {
+            foreach (var table in preparedTables)
+            {
+                await RunBqAsync(
+                    plan,
+                    [
+                        "rm",
+                        "--force",
+                        "--table",
+                        FormatTableSpec(plan, table.StagingTableName)
+                    ],
+                    cancellationToken);
+            }
+        }
+
+        AnsiConsole.MarkupLine("[green]✓ BigQuery atualizado[/]");
+    }
+
+    internal static string BuildStagingTableNameForTest(string destinationTableName, string releaseId) =>
+        BuildStagingTableName(destinationTableName, releaseId);
+
+    private async Task RunBqAsync(
+        BigQueryPublicationPlan plan,
+        IReadOnlyList<string> commandArguments,
+        CancellationToken cancellationToken)
+    {
+        var arguments = new List<string>();
+        if (!string.IsNullOrWhiteSpace(plan.Location))
+            arguments.Add($"--location={plan.Location}");
+
+        arguments.AddRange(commandArguments);
+        await _commandRunner.RunAsync(plan.BqExecutable, arguments, cancellationToken);
+    }
+
+    private async Task ValidateTargetDatasetAsync(
+        BigQueryPublicationPlan plan,
+        CancellationToken cancellationToken)
+    {
+        AnsiConsole.MarkupLine(
+            $"[grey]BigQuery:[/] validando autenticação e dataset [cyan]{FormatDatasetSpec(plan).EscapeMarkup()}[/]");
+        await RunBqAsync(
+            plan,
+            [
+                "show",
+                "--format=none",
+                FormatDatasetSpec(plan)
+            ],
+            cancellationToken);
+    }
+
+    private static string FormatDatasetSpec(BigQueryPublicationPlan plan) =>
+        $"{plan.ProjectId}:{plan.Dataset}";
+
+    private static string FormatTableSpec(BigQueryPublicationPlan plan, string tableName) =>
+        $"{plan.ProjectId}:{plan.Dataset}.{tableName}";
+
+    private static string BuildStagingTableName(string destinationTableName, string releaseId)
+    {
+        var suffix = InvalidTableNameCharacterPattern.Replace(releaseId.Trim('/'), "_").Trim('_');
+        if (string.IsNullOrWhiteSpace(suffix))
+            suffix = "release";
+
+        return $"{destinationTableName}__staging_{suffix}";
+    }
+
+    private sealed record PreparedBigQueryTable(
+        BigQueryTablePublication Source,
+        string StagingTableName);
+}

--- a/src/ETL/Processor/BigQuery/IBigQueryCommandRunner.cs
+++ b/src/ETL/Processor/BigQuery/IBigQueryCommandRunner.cs
@@ -1,0 +1,9 @@
+namespace CNPJExporter.Processors.BigQuery;
+
+internal interface IBigQueryCommandRunner
+{
+    Task RunAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ETL/Processor/BigQuery/ProcessBigQueryCommandRunner.cs
+++ b/src/ETL/Processor/BigQuery/ProcessBigQueryCommandRunner.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace CNPJExporter.Processors.BigQuery;
+
+internal sealed class ProcessBigQueryCommandRunner : IBigQueryCommandRunner
+{
+    public async Task RunAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            UseShellExecute = false,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using var process = new Process { StartInfo = startInfo };
+        try
+        {
+            process.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            throw new InvalidOperationException($"Comando BigQuery não encontrado: {executable}.", ex);
+        }
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        var output = await outputTask;
+        var error = await errorTask;
+        if (process.ExitCode == 0)
+            return;
+
+        var details = string.IsNullOrWhiteSpace(error) ? output : error;
+        throw new InvalidOperationException(
+            $"Comando BigQuery falhou com exit code {process.ExitCode}: {executable} {Describe(arguments)}. {Truncate(details)}");
+    }
+
+    private static string Describe(IEnumerable<string> arguments) =>
+        string.Join(" ", arguments.Select(argument => argument.Contains(' ', StringComparison.Ordinal) ? $"\"{argument}\"" : argument));
+
+    private static string Truncate(string value)
+    {
+        var normalized = value.Trim();
+        return normalized.Length <= 2_000 ? normalized : normalized[..2_000] + "...";
+    }
+}

--- a/src/ETL/Processor/Commands/PipelineCommand.cs
+++ b/src/ETL/Processor/Commands/PipelineCommand.cs
@@ -5,11 +5,15 @@ using CNPJExporter.Modules.Receita;
 using CNPJExporter.Modules.Receita.Downloaders;
 using CNPJExporter.Processors.Models;
 using CNPJExporter.Processors;
+using CNPJExporter.Processors.BigQuery;
 using CNPJExporter.Utils;
 using System.Security.Cryptography;
 using System.Text;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using CnoBigQueryParquetExporter = CNPJExporter.Modules.Cno.BigQueryParquetExporter;
+using ReceitaBigQueryParquetExporter = CNPJExporter.Modules.Receita.BigQueryParquetExporter;
+using RntrcBigQueryParquetExporter = CNPJExporter.Modules.Rntrc.BigQueryParquetExporter;
 
 namespace CNPJExporter.Commands;
 
@@ -37,7 +41,11 @@ public sealed class PipelineCommand : AsyncCommand<PipelineSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, PipelineSettings settings)
     {
-        var totalSteps = settings.CleanupOnSuccess ? 6 : 5;
+        var bigQueryEnabled = ShouldRunBigQuery(
+            AppConfig.Current.BigQuery,
+            message => AnsiConsole.MarkupLine($"[yellow]{message.EscapeMarkup()}[/]"));
+
+        var totalSteps = 5 + (bigQueryEnabled ? 1 : 0) + (settings.CleanupOnSuccess ? 1 : 0);
         var currentMonth = DatasetPublicationPolicy.GetCurrentMonth();
         var receitaIntegration = new DataIntegration();
         receitaIntegration.Descriptor.Validate();
@@ -162,7 +170,30 @@ public sealed class PipelineCommand : AsyncCommand<PipelineSettings>
                     AppConfig.Current.Paths.OutputDir)
                 : publishedInfo?.BaseZip.ToPublication() ?? ZipArtifactPublication.Missing;
 
-            AnsiConsole.MarkupLine($"[cyan]5/{totalSteps} Gerando e enviando estatística final...[/]");
+            var releaseInfoStep = 5;
+            if (bigQueryEnabled)
+            {
+                AnsiConsole.MarkupLine($"[cyan]{releaseInfoStep}/{totalSteps} Atualizando BigQuery...[/]");
+                if (receitaChanged)
+                {
+                    var receitaParquetRoot = DatasetPathResolver.GetDatasetPath(
+                        AppConfig.Current.Paths.ParquetDir,
+                        selectedMonth);
+                    await new ReceitaBigQueryParquetExporter(
+                        receitaParquetRoot,
+                        AppConfig.Current.Shards.PrefixLength)
+                        .MaterializeAsync(selectedMonth);
+                }
+
+                var bigQueryPlan = BigQueryPublicationPlanner.Build(
+                    AppConfig.Current.BigQuery,
+                    releaseId,
+                    await BuildBigQuerySourcesAsync(selectedMonth, receitaChanged, integrationSummaries));
+                await new BigQueryPublisher().PublishAsync(bigQueryPlan);
+                releaseInfoStep++;
+            }
+
+            AnsiConsole.MarkupLine($"[cyan]{releaseInfoStep}/{totalSteps} Gerando e enviando estatística final...[/]");
             var publication = BuildReleaseInfoPublication(
                 ingestor,
                 selectedMonth,
@@ -180,7 +211,7 @@ public sealed class PipelineCommand : AsyncCommand<PipelineSettings>
 
         if (settings.CleanupOnSuccess)
         {
-            AnsiConsole.MarkupLine($"[cyan]6/{totalSteps} Removendo insumos locais de {selectedMonth}...[/]");
+            AnsiConsole.MarkupLine($"[cyan]{totalSteps}/{totalSteps} Removendo insumos locais de {selectedMonth}...[/]");
             await LocalArtifactCleaner.CleanupDatasetArtifactsAsync(selectedMonth);
             AnsiConsole.MarkupLine($"[green]✓ Insumos locais de {selectedMonth} removidos[/]");
         }
@@ -195,6 +226,17 @@ public sealed class PipelineCommand : AsyncCommand<PipelineSettings>
         return DatasetPublicationPolicy.NoNewDatasetExitCode;
     }
 
+    internal static bool ShouldRunBigQuery(
+        AppConfig.BigQuerySettings settings,
+        Action<string> warningSink)
+    {
+        if (settings.Enabled)
+            return true;
+
+        warningSink("BigQuery não habilitado em config.json; atualização/publicação de tabelas no BigQuery será ignorada.");
+        return false;
+    }
+
     private static string ResolveLocalBaseDatasetKey(string? publishedMonth, string currentMonth)
     {
         return DatasetPathResolver.ResolveLatestLocalDatasetKey(AppConfig.Current.Paths)
@@ -206,6 +248,38 @@ public sealed class PipelineCommand : AsyncCommand<PipelineSettings>
     {
         var paths = AppConfig.Current.Paths;
         return new DataIntegrationPaths(paths.DataDir, paths.ParquetDir, paths.OutputDir, paths.DownloadDir);
+    }
+
+    private static async Task<IReadOnlyList<BigQueryParquetSource>> BuildBigQuerySourcesAsync(
+        string selectedMonth,
+        bool receitaChanged,
+        IReadOnlyList<DataIntegrationRunSummary> integrationSummaries)
+    {
+        var sources = new List<BigQueryParquetSource>();
+
+        if (receitaChanged)
+        {
+            var receitaParquetRoot = DatasetPathResolver.GetDatasetPath(
+                AppConfig.Current.Paths.ParquetDir,
+                selectedMonth);
+            sources.Add(ReceitaBigQueryParquetExporter.GetSource(receitaParquetRoot));
+        }
+
+        foreach (var source in DataIntegrationShardSource.FromRunSummaries(integrationSummaries))
+        {
+            var bigQuerySource = source.Key switch
+            {
+                CnoBigQueryParquetExporter.TableName => await new CnoBigQueryParquetExporter(source.ParquetGlob)
+                    .MaterializeAsync(),
+                RntrcBigQueryParquetExporter.TableName => await new RntrcBigQueryParquetExporter(source.ParquetGlob)
+                    .MaterializeAsync(),
+                _ => new BigQueryParquetSource(source.Key, [source.ParquetGlob])
+            };
+
+            sources.Add(bigQuerySource);
+        }
+
+        return sources;
     }
 
     private static bool RequiresModuleShardBootstrap(

--- a/src/ETL/Processor/Configuration/AppConfig.cs
+++ b/src/ETL/Processor/Configuration/AppConfig.cs
@@ -4,6 +4,9 @@ namespace CNPJExporter.Configuration;
 
 public class AppConfig
 {
+    public const string BigQueryEnabledEnvironmentVariable = "OPENCNPJ_BIGQUERY_ENABLED";
+    public const string BigQueryProjectIdEnvironmentVariable = "OPENCNPJ_BIGQUERY_PROJECT_ID";
+
     public PathsConfig Paths { get; set; } = new();
     public RcloneSettings Rclone { get; set; } = new();
     public DuckDbSettings DuckDb { get; set; } = new();
@@ -11,6 +14,7 @@ public class AppConfig
     public DownloaderSettings Downloader { get; set; } = new();
     public CnoIntegrationSettings CnoIntegration { get; set; } = new();
     public RntrcIntegrationSettings RntrcIntegration { get; set; } = new();
+    public BigQuerySettings BigQuery { get; set; } = new();
 
     public class PathsConfig
     {
@@ -71,6 +75,17 @@ public class AppConfig
         public int RefreshHours { get; set; } = 24;
     }
 
+    public class BigQuerySettings
+    {
+        public bool Enabled { get; set; } = false;
+        public string ProjectId { get; set; } = string.Empty;
+        public string Dataset { get; set; } = string.Empty;
+        public string TablePrefix { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public string BqExecutable { get; set; } = "bq";
+        public bool KeepStagingTables { get; set; } = false;
+    }
+
     public static AppConfig Current { get; private set; } = new();
 
     public static AppConfig Load(string? path = null)
@@ -87,7 +102,7 @@ public class AppConfig
                 });
                 if (cfg != null)
                 {
-                    Current = cfg;
+                    Current = ApplyEnvironmentOverrides(cfg);
                     return Current;
                 }
             }
@@ -95,7 +110,30 @@ public class AppConfig
         catch
         {
         }
-        Current = new();
+        Current = ApplyEnvironmentOverrides(new());
         return Current;
+    }
+
+    private static AppConfig ApplyEnvironmentOverrides(AppConfig config)
+    {
+        var bigQueryEnabled = Environment.GetEnvironmentVariable(BigQueryEnabledEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(bigQueryEnabled))
+            config.BigQuery.Enabled = ParseBooleanEnvironmentValue(bigQueryEnabled, BigQueryEnabledEnvironmentVariable);
+
+        var bigQueryProjectId = Environment.GetEnvironmentVariable(BigQueryProjectIdEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(bigQueryProjectId))
+            config.BigQuery.ProjectId = bigQueryProjectId.Trim();
+
+        return config;
+    }
+
+    private static bool ParseBooleanEnvironmentValue(string value, string name)
+    {
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "true" => true,
+            "false" => false,
+            _ => throw new InvalidOperationException($"{name} deve ser true ou false.")
+        };
     }
 }

--- a/src/ETL/Processor/config.json
+++ b/src/ETL/Processor/config.json
@@ -43,5 +43,14 @@
     "Enabled": true,
     "PackageShowUrl": "https://dados.antt.gov.br/api/3/action/package_show?id=b4a055d1-97a2-46f1-9461-cb17fbc6b6b3",
     "RefreshHours": 24
+  },
+  "BigQuery": {
+    "Enabled": false,
+    "ProjectId": "",
+    "Dataset": "public",
+    "TablePrefix": "",
+    "Location": "",
+    "BqExecutable": "bq",
+    "KeepStagingTables": false
   }
 }

--- a/src/ETL/Tests/AppConfigTests.cs
+++ b/src/ETL/Tests/AppConfigTests.cs
@@ -16,4 +16,106 @@ public sealed class AppConfigTests
         Assert.AreEqual(string.Empty, new CnoIntegrationOptions().PublicShareRoot);
         Assert.AreEqual(string.Empty, new RntrcIntegrationOptions().PackageShowUrl);
     }
+
+    [TestMethod]
+    public void BigQuery_ShouldBeDisabledByDefault()
+    {
+        var settings = new AppConfig.BigQuerySettings();
+
+        Assert.IsFalse(settings.Enabled);
+        Assert.AreEqual(string.Empty, settings.ProjectId);
+        Assert.AreEqual("bq", settings.BqExecutable);
+    }
+
+    [TestMethod]
+    public void Load_ShouldOverrideBigQueryProjectIdFromEnvironment()
+    {
+        var previousEnabled = Environment.GetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable);
+        var previous = Environment.GetEnvironmentVariable(AppConfig.BigQueryProjectIdEnvironmentVariable);
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-config-{Guid.NewGuid():N}");
+        var configPath = Path.Combine(tempRoot, "config.json");
+
+        try
+        {
+            Directory.CreateDirectory(tempRoot);
+            File.WriteAllText(
+                configPath,
+                """
+                {
+                  "BigQuery": {
+                    "Enabled": true,
+                    "ProjectId": "project-from-config",
+                    "Dataset": "public"
+                  }
+                }
+                """);
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, "false");
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryProjectIdEnvironmentVariable, " project-from-env ");
+
+            var config = AppConfig.Load(configPath);
+
+            Assert.IsFalse(config.BigQuery.Enabled);
+            Assert.AreEqual("project-from-env", config.BigQuery.ProjectId);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, previousEnabled);
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryProjectIdEnvironmentVariable, previous);
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void Load_ShouldEnableBigQueryFromEnvironment()
+    {
+        var previous = Environment.GetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable);
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-config-{Guid.NewGuid():N}");
+        var configPath = Path.Combine(tempRoot, "config.json");
+
+        try
+        {
+            Directory.CreateDirectory(tempRoot);
+            File.WriteAllText(
+                configPath,
+                """
+                {
+                  "BigQuery": {
+                    "Enabled": false,
+                    "Dataset": "public"
+                  }
+                }
+                """);
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, "true");
+
+            var config = AppConfig.Load(configPath);
+
+            Assert.IsTrue(config.BigQuery.Enabled);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, previous);
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void Load_ShouldRejectNonBooleanBigQueryEnabledEnvironmentValue()
+    {
+        var previous = Environment.GetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, "1");
+
+            var ex = Assert.ThrowsException<InvalidOperationException>(() => AppConfig.Load("missing-config.json"));
+
+            StringAssert.Contains(ex.Message, "true ou false");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AppConfig.BigQueryEnabledEnvironmentVariable, previous);
+        }
+    }
 }

--- a/src/ETL/Tests/BigQueryPublicationPlannerTests.cs
+++ b/src/ETL/Tests/BigQueryPublicationPlannerTests.cs
@@ -1,0 +1,103 @@
+using CNPJExporter.Configuration;
+using CNPJExporter.Integrations;
+using CNPJExporter.Processors.BigQuery;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class BigQueryPublicationPlannerTests
+{
+    [TestMethod]
+    public void Build_ShouldMapCanonicalParquetSources()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-bigquery-plan-{Guid.NewGuid():N}");
+        try
+        {
+            var sourcePath = Path.Combine(tempRoot, "receita.parquet");
+            Touch(sourcePath);
+
+            var plan = BigQueryPublicationPlanner.Build(
+                new AppConfig.BigQuerySettings
+                {
+                    Enabled = true,
+                    ProjectId = "opencnpj-bigquery",
+                    Dataset = "public",
+                    TablePrefix = "oc_"
+                },
+                "release-1",
+                [new BigQueryParquetSource("receita", [sourcePath])]);
+
+            Assert.AreEqual("oc_receita", plan.Tables.Single().DestinationTableName);
+            Assert.AreEqual(sourcePath, plan.Tables.Single().SourcePaths.Single());
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void Build_ShouldRejectDisabledBigQuerySettings()
+    {
+        var ex = Assert.ThrowsException<InvalidOperationException>(() =>
+            BigQueryPublicationPlanner.Build(
+                new AppConfig.BigQuerySettings
+                {
+                    Enabled = false
+                },
+                "release-1",
+                []));
+
+        StringAssert.Contains(ex.Message, "BigQuery.Enabled=false");
+    }
+
+    [TestMethod]
+    public void Build_ShouldThrowClearError_WhenEnabledConfigIsIncomplete()
+    {
+        var ex = Assert.ThrowsException<InvalidOperationException>(() =>
+            BigQueryPublicationPlanner.Build(
+                new AppConfig.BigQuerySettings
+                {
+                    Enabled = true,
+                    Dataset = "public"
+                },
+                "release-1",
+                []));
+
+        StringAssert.Contains(ex.Message, "BigQuery.ProjectId");
+    }
+
+    [TestMethod]
+    public void Planner_ShouldNotKnowModuleSpecificTables()
+    {
+        var plannerSource = File.ReadAllText(FindPlannerSource());
+
+        Assert.IsFalse(plannerSource.Contains("empresa", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(plannerSource.Contains("estabelecimento", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(plannerSource.Contains("cno", StringComparison.OrdinalIgnoreCase));
+        Assert.IsFalse(plannerSource.Contains("rntrc", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string FindPlannerSource()
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrWhiteSpace(current))
+        {
+            var candidate = Path.Combine(current, "src", "ETL", "Processor", "BigQuery", "BigQueryPublicationPlanner.cs");
+            if (File.Exists(candidate))
+                return candidate;
+
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        throw new FileNotFoundException("BigQueryPublicationPlanner.cs não encontrado.");
+    }
+
+    private static void Touch(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "placeholder");
+    }
+}

--- a/src/ETL/Tests/BigQueryPublisherTests.cs
+++ b/src/ETL/Tests/BigQueryPublisherTests.cs
@@ -1,0 +1,113 @@
+using CNPJExporter.Processors.BigQuery;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class BigQueryPublisherTests
+{
+    [TestMethod]
+    public async Task PublishAsync_ShouldLoadStagingBeforeReplacingFinalTable()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-bigquery-publish-{Guid.NewGuid():N}");
+        try
+        {
+            var sourcePath = Path.Combine(tempRoot, "receita.parquet");
+            Directory.CreateDirectory(tempRoot);
+            File.WriteAllText(sourcePath, "placeholder");
+
+            var runner = new RecordingBigQueryCommandRunner();
+            var publisher = new BigQueryPublisher(runner);
+            var plan = new BigQueryPublicationPlan(
+                ProjectId: "opencnpj-bigquery",
+                Dataset: "public",
+                ReleaseId: "release-1",
+                BqExecutable: "bq",
+                Location: "US",
+                KeepStagingTables: false,
+                Tables: [new BigQueryTablePublication("receita", "receita", [sourcePath])]);
+
+            await publisher.PublishAsync(plan);
+
+            CollectionAssert.AreEqual(
+                new[] { "show", "load", "cp", "rm" },
+                runner.Commands.Select(CommandName).ToArray());
+
+            var showCommand = string.Join(" ", runner.Commands[0].Args);
+            StringAssert.Contains(showCommand, "opencnpj-bigquery:public");
+            Assert.IsFalse(showCommand.Contains(".receita", StringComparison.Ordinal));
+
+            var loadCommand = string.Join(" ", runner.Commands[1].Args);
+            StringAssert.Contains(loadCommand, "--location=US");
+            StringAssert.Contains(loadCommand, "opencnpj-bigquery:public.receita__staging_release_1");
+            StringAssert.Contains(loadCommand, sourcePath);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_ShouldAppendAdditionalParquetPartsToSameStagingTable()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-bigquery-publish-{Guid.NewGuid():N}");
+        try
+        {
+            var sourcePaths = new[]
+            {
+                Path.Combine(tempRoot, "part-00000.parquet"),
+                Path.Combine(tempRoot, "part-00001.parquet")
+            };
+            Directory.CreateDirectory(tempRoot);
+            foreach (var sourcePath in sourcePaths)
+                File.WriteAllText(sourcePath, "placeholder");
+
+            var runner = new RecordingBigQueryCommandRunner();
+            var publisher = new BigQueryPublisher(runner);
+            var plan = new BigQueryPublicationPlan(
+                ProjectId: "opencnpj-bigquery",
+                Dataset: "public",
+                ReleaseId: "release-1",
+                BqExecutable: "bq",
+                Location: "US",
+                KeepStagingTables: false,
+                Tables: [new BigQueryTablePublication("receita", "receita", sourcePaths)]);
+
+            await publisher.PublishAsync(plan);
+
+            CollectionAssert.AreEqual(
+                new[] { "show", "load", "load", "cp", "rm" },
+                runner.Commands.Select(CommandName).ToArray());
+
+            var firstLoad = string.Join(" ", runner.Commands[1].Args);
+            var secondLoad = string.Join(" ", runner.Commands[2].Args);
+            StringAssert.Contains(firstLoad, "--replace");
+            Assert.IsFalse(secondLoad.Contains("--replace", StringComparison.Ordinal));
+            StringAssert.Contains(firstLoad, sourcePaths[0]);
+            StringAssert.Contains(secondLoad, sourcePaths[1]);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static string CommandName(RecordedBigQueryCommand command) =>
+        command.Args.First(arg => arg is "show" or "load" or "cp" or "rm");
+
+    private sealed record RecordedBigQueryCommand(string Executable, IReadOnlyList<string> Args);
+
+    private sealed class RecordingBigQueryCommandRunner : IBigQueryCommandRunner
+    {
+        public List<RecordedBigQueryCommand> Commands { get; } = [];
+
+        public Task RunAsync(string executable, IReadOnlyList<string> arguments, CancellationToken cancellationToken = default)
+        {
+            Commands.Add(new RecordedBigQueryCommand(executable, arguments.ToArray()));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ETL/Tests/CnoBigQueryParquetExporterTests.cs
+++ b/src/ETL/Tests/CnoBigQueryParquetExporterTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using CNPJExporter.Modules.Cno.Models;
+using DuckDB.NET.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CnoBigQueryParquetExporter = CNPJExporter.Modules.Cno.BigQueryParquetExporter;
+using CnoParquetProcessor = CNPJExporter.Modules.Cno.Processors.ParquetProcessor;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class CnoBigQueryParquetExporterTests
+{
+    [TestMethod]
+    public async Task MaterializeAsync_ShouldCreateColumnarParquetWithoutPayloadJson()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-cno-bigquery-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var files = new ExtractedFiles(
+                WriteCsv(tempRoot, "cno.csv", 26, [
+                    "010010092278,105,BRASIL,1992-02-20,1992-02-21,2022-05-17,,71215207,02688984000170,0057,Obra A,9701,Brasilia,OUTROS,SOF SUL,SN,Bairro,DF,,Lote,m2,412.00,02,2002-11-30,Empresa A,001"
+                ]),
+                WriteCsv(tempRoot, "cno_cnaes.csv", 3, [
+                    "010010092278,4120400,2022-05-17"
+                ]),
+                WriteCsv(tempRoot, "cno_vinculos.csv", 6, [
+                    "010010092278,2022-05-17,,2022-05-17,0053,12.345.678/0001-95"
+                ]),
+                WriteCsv(tempRoot, "cno_areas.csv", 7, [
+                    "010010092278,1,Residencial,Construcao,Principal,,412.00"
+                ]));
+            var canonicalParquetPath = Path.Combine(tempRoot, "cno.parquet");
+
+            await new CnoParquetProcessor().ConvertToParquetAsync(
+                files,
+                canonicalParquetPath,
+                new DateTimeOffset(2026, 4, 14, 12, 0, 0, TimeSpan.Zero),
+                shardPrefixLength: 3);
+
+            var source = await new CnoBigQueryParquetExporter(canonicalParquetPath).MaterializeAsync();
+
+            Assert.AreEqual("cno", source.TableName);
+            Assert.AreEqual(1, source.SourcePaths.Count);
+            Assert.IsTrue(File.Exists(source.SourcePaths.Single()));
+
+            await using var connection = new DuckDBConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var columnNames = await ReadColumnNamesAsync(connection, source.SourcePaths.Single());
+            Assert.IsFalse(columnNames.Contains("payload_json"), "BigQuery CNO não deve carregar payload_json.");
+            CollectionAssert.IsSubsetOf(
+                new[] { "cnpj", "cnpj_prefix", "updated_at", "obras" },
+                columnNames.ToArray());
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+                SELECT cnpj, cnpj_prefix, updated_at, to_json(obras) AS obras_json
+                FROM read_parquet('{EscapeSqlLiteral(source.SourcePaths.Single())}')
+                WHERE cnpj = '02688984000170'";
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("02688984000170", reader.GetString(0));
+            Assert.AreEqual(26, reader.GetInt32(1));
+            Assert.AreEqual("2026-04-14T12:00:00.0000000+00:00", reader.GetString(2));
+
+            using var obras = JsonDocument.Parse(reader.GetString(3));
+            Assert.AreEqual(1, obras.RootElement.GetArrayLength());
+            var obra = obras.RootElement[0];
+            Assert.AreEqual("010010092278", obra.GetProperty("cno").GetString());
+            Assert.AreEqual("ATIVA", obra.GetProperty("situacao").GetProperty("descricao").GetString());
+            Assert.AreEqual("0057", obra.GetProperty("qualificacao_responsavel").GetProperty("codigo").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static async Task<HashSet<string>> ReadColumnNamesAsync(DuckDBConnection connection, string parquetPath)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT * FROM read_parquet('{EscapeSqlLiteral(parquetPath)}') LIMIT 0";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        return Enumerable
+            .Range(0, reader.FieldCount)
+            .Select(reader.GetName)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string WriteCsv(string directory, string fileName, int columnCount, IReadOnlyList<string> rows)
+    {
+        var path = Path.Combine(directory, fileName);
+        var header = string.Join(",", Enumerable.Range(1, columnCount).Select(static index => $"col{index}"));
+        File.WriteAllLines(path, [header, .. rows]);
+        return path;
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/ETL/Tests/DeployScriptTests.cs
+++ b/src/ETL/Tests/DeployScriptTests.cs
@@ -34,6 +34,72 @@ public sealed class DeployScriptTests
     }
 
     [TestMethod]
+    public void Deploy_ShouldNotForceReceitaMonthByDefault()
+    {
+        var script = File.ReadAllText(FindDeployScript());
+
+        StringAssert.Contains(
+            script,
+            "MONTH=\"\"");
+        Assert.IsFalse(
+            script.Contains("MONTH=\"2026-", StringComparison.Ordinal),
+            "deploy.sh must not force a Receita month; --month should only be used when passed explicitly.");
+        Assert.IsTrue(
+            script.Contains("if [[ -n \"$MONTH\" ]]; then", StringComparison.Ordinal),
+            "deploy.sh must keep --month conditional.");
+    }
+
+    [TestMethod]
+    public void Deploy_ShouldRequireBigQueryCommandOnlyWhenBigQueryIsEnabled()
+    {
+        var script = File.ReadAllText(FindDeployScript());
+        var functionIndex = script.IndexOf("require_bigquery_command_if_enabled()", StringComparison.Ordinal);
+        Assert.IsTrue(functionIndex >= 0, "deploy.sh must define a conditional BigQuery command check.");
+
+        var function = script[functionIndex..];
+        var nextFunctionIndex = function.IndexOf("\njson_field()", StringComparison.Ordinal);
+        if (nextFunctionIndex >= 0)
+            function = function[..nextFunctionIndex];
+
+        Assert.IsTrue(
+            function.Contains("BigQuery.Enabled", StringComparison.Ordinal),
+            "deploy.sh must be able to read the BigQuery enabled flag from ETL config.");
+        Assert.IsTrue(
+            script.Contains("OPENCNPJ_BIGQUERY_ENABLED", StringComparison.Ordinal),
+            "deploy.sh must accept the BigQuery enabled flag from the deployment environment.");
+        Assert.IsTrue(
+            function.Contains("read_bigquery_enabled", StringComparison.Ordinal),
+            "deploy.sh must resolve the BigQuery enabled flag through the override-aware helper.");
+        Assert.IsTrue(
+            function.Contains("BigQuery.BqExecutable", StringComparison.Ordinal),
+            "deploy.sh must honor the configured bq executable.");
+        Assert.IsTrue(
+            function.Contains("BigQuery não habilitado", StringComparison.Ordinal),
+            "deploy.sh must warn and continue when BigQuery is disabled.");
+        Assert.IsTrue(
+            function.Contains("BigQuery.ProjectId", StringComparison.Ordinal),
+            "deploy.sh must validate ProjectId before running the ETL when BigQuery is enabled.");
+        Assert.IsTrue(
+            function.Contains("OPENCNPJ_BIGQUERY_PROJECT_ID", StringComparison.Ordinal),
+            "deploy.sh must accept the BigQuery project id from the deployment environment.");
+        Assert.IsTrue(
+            function.Contains("BigQuery.Dataset", StringComparison.Ordinal),
+            "deploy.sh must validate Dataset before running the ETL when BigQuery is enabled.");
+        Assert.IsTrue(
+            function.Contains("BigQuery.Location", StringComparison.Ordinal),
+            "deploy.sh must honor the configured BigQuery location during validation.");
+        Assert.IsTrue(
+            function.Contains("require_command \"$executable\"", StringComparison.Ordinal),
+            "deploy.sh must require bq only after BigQuery is enabled.");
+        Assert.IsTrue(
+            function.Contains("show --format=none \"${project_id}:${dataset}\"", StringComparison.Ordinal),
+            "deploy.sh must validate ambient authentication and dataset access using the configured project.");
+        Assert.IsFalse(
+            function.Contains("GOOGLE_" + "APPLICATION_" + "CREDENTIALS", StringComparison.Ordinal),
+            "deploy.sh must not require a key file.");
+    }
+
+    [TestMethod]
     public void CleanupDatasetArtifacts_ShouldPreserveParquetDirectory()
     {
         var script = File.ReadAllText(FindDeployScript());
@@ -235,6 +301,31 @@ public sealed class DeployScriptTests
         Assert.IsFalse(
             script.Contains("--release-id", StringComparison.Ordinal),
             "docker-entrypoint.sh should let deploy.sh generate a fresh release id only when there is work to publish.");
+    }
+
+    [TestMethod]
+    public void DockerEntrypoint_ShouldActivateBigQueryCredentialsFromBase64Environment()
+    {
+        var script = File.ReadAllText(FindDockerEntrypointScript());
+
+        Assert.IsTrue(
+            script.Contains("OPENCNPJ_GOOGLE_CREDENTIALS_BASE64", StringComparison.Ordinal),
+            "docker-entrypoint.sh must accept BigQuery credentials from a Dokploy secret env.");
+        Assert.IsTrue(
+            script.Contains("OPENCNPJ_BIGQUERY_ENABLED", StringComparison.Ordinal),
+            "docker-entrypoint.sh must activate BigQuery credentials when BigQuery is enabled by env.");
+        Assert.IsTrue(
+            script.Contains("base64 -d", StringComparison.Ordinal),
+            "docker-entrypoint.sh must decode the credentials only at runtime.");
+        Assert.IsTrue(
+            script.Contains("gcloud auth activate-service-account", StringComparison.Ordinal),
+            "docker-entrypoint.sh must activate the decoded credentials for bq.");
+        Assert.IsTrue(
+            script.Contains("rm -f \"$TMP_GOOGLE_CREDENTIALS\"", StringComparison.Ordinal),
+            "docker-entrypoint.sh must remove the temporary credential file after activation.");
+        Assert.IsFalse(
+            script.Contains("GOOGLE_" + "APPLICATION_" + "CREDENTIALS", StringComparison.Ordinal),
+            "docker-entrypoint.sh must not require a mounted credential file.");
     }
 
     [TestMethod]

--- a/src/ETL/Tests/PipelineCommandBigQueryTests.cs
+++ b/src/ETL/Tests/PipelineCommandBigQueryTests.cs
@@ -1,0 +1,36 @@
+using CNPJExporter.Commands;
+using CNPJExporter.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class PipelineCommandBigQueryTests
+{
+    [TestMethod]
+    public void ShouldRunBigQuery_ShouldWarnAndSkip_WhenConfigIsDisabled()
+    {
+        var warnings = new List<string>();
+
+        var shouldRun = PipelineCommand.ShouldRunBigQuery(
+            new AppConfig.BigQuerySettings { Enabled = false },
+            warnings.Add);
+
+        Assert.IsFalse(shouldRun);
+        Assert.AreEqual(1, warnings.Count);
+        StringAssert.Contains(warnings.Single(), "BigQuery não habilitado");
+    }
+
+    [TestMethod]
+    public void ShouldRunBigQuery_ShouldNotWarn_WhenConfigIsEnabled()
+    {
+        var warnings = new List<string>();
+
+        var shouldRun = PipelineCommand.ShouldRunBigQuery(
+            new AppConfig.BigQuerySettings { Enabled = true },
+            warnings.Add);
+
+        Assert.IsTrue(shouldRun);
+        Assert.AreEqual(0, warnings.Count);
+    }
+}

--- a/src/ETL/Tests/ReceitaBigQueryParquetExporterTests.cs
+++ b/src/ETL/Tests/ReceitaBigQueryParquetExporterTests.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using CNPJExporter.Modules.Receita;
+using DuckDB.NET.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class ReceitaBigQueryParquetExporterTests
+{
+    [TestMethod]
+    public void GetSource_ShouldExposeSingleCanonicalReceitaSource()
+    {
+        var parquetRoot = Path.Combine(Path.GetTempPath(), "opencnpj", "parquet", "2026-04");
+
+        var source = BigQueryParquetExporter.GetSource(parquetRoot);
+
+        Assert.AreEqual("receita", source.TableName);
+        Assert.AreEqual(0, source.SourcePaths.Count);
+    }
+
+    [TestMethod]
+    public async Task MaterializeAsync_ShouldCreateColumnarParquetPartsForReceita()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-receita-bigquery-{Guid.NewGuid():N}");
+        var parquetRoot = Path.Combine(tempRoot, "parquet");
+
+        try
+        {
+            await using (var connection = new DuckDBConnection("Data Source=:memory:"))
+            {
+                await connection.OpenAsync();
+                await SeedReceitaProjectionDataAsync(connection, parquetRoot);
+            }
+
+            var outputPaths = await new BigQueryParquetExporter(parquetRoot, shardPrefixLength: 3)
+                .MaterializeAsync("2026-04");
+
+            Assert.AreEqual(1, outputPaths.Count);
+            Assert.IsTrue(File.Exists(outputPaths.Single()));
+
+            var source = BigQueryParquetExporter.GetSource(parquetRoot);
+            CollectionAssert.AreEqual(outputPaths.ToArray(), source.SourcePaths.ToArray());
+
+            await using (var connection = new DuckDBConnection("Data Source=:memory:"))
+            {
+                await connection.OpenAsync();
+                await using var cmd = connection.CreateCommand();
+                cmd.CommandText = $@"
+                    SELECT
+                        cnpj,
+                        cnpj_prefix,
+                        razao_social,
+                        nome_fantasia,
+                        situacao_cadastral,
+                        data_situacao_cadastral,
+                        matriz_filial,
+                        cnae_principal,
+                        capital_social,
+                        opcao_simples,
+                        data_exclusao_simples,
+                        data_exclusao_mei,
+                        codigo_municipio,
+                        ente_federativo,
+                        nome_cidade_exterior,
+                        codigo_pais,
+                        to_json(cnaes) AS cnaes_json,
+                        to_json(qualificacao_responsavel) AS qualificacao_responsavel_json,
+                        to_json(motivo_situacao_cadastral) AS motivo_situacao_cadastral_json,
+                        to_json(pais) AS pais_json,
+                        to_json(QSA) AS qsa_json
+                    FROM read_parquet('{EscapeSqlLiteral(outputPaths.Single())}')";
+
+                await using var reader = await cmd.ExecuteReaderAsync();
+                Assert.IsTrue(await reader.ReadAsync());
+
+                Assert.AreEqual("60701190000104", reader.GetString(0));
+                Assert.AreEqual(607, reader.GetInt32(1));
+                Assert.AreEqual("EMPRESA TESTE LTDA", reader.GetString(2));
+                Assert.AreEqual("EMPRESA TESTE", reader.GetString(3));
+                Assert.AreEqual("Ativa", reader.GetString(4));
+                Assert.AreEqual(new DateTime(2024, 1, 15), reader.GetDateTime(5));
+                Assert.AreEqual("Matriz", reader.GetString(6));
+                Assert.AreEqual("6201501", reader.GetString(7));
+                Assert.AreEqual(10000.00m, reader.GetDecimal(8));
+                Assert.IsTrue(reader.GetBoolean(9));
+                Assert.AreEqual(new DateTime(2024, 2, 20), reader.GetDateTime(10));
+                Assert.AreEqual(new DateTime(2024, 3, 21), reader.GetDateTime(11));
+                Assert.AreEqual("7107", reader.GetString(12));
+                Assert.AreEqual("ENTE TESTE", reader.GetString(13));
+                Assert.AreEqual("MONTEVIDEO", reader.GetString(14));
+                Assert.AreEqual("105", reader.GetString(15));
+
+                using var cnaes = JsonDocument.Parse(reader.GetString(16));
+                Assert.AreEqual(2, cnaes.RootElement.GetArrayLength());
+                Assert.AreEqual("6201501", cnaes.RootElement[0].GetProperty("codigo").GetString());
+                Assert.IsTrue(cnaes.RootElement[0].GetProperty("is_principal").GetBoolean());
+                Assert.AreEqual("6202300", cnaes.RootElement[1].GetProperty("codigo").GetString());
+
+                using var qualificacao = JsonDocument.Parse(reader.GetString(17));
+                Assert.AreEqual("49", qualificacao.RootElement.GetProperty("codigo").GetString());
+                Assert.AreEqual("Sócio-Administrador", qualificacao.RootElement.GetProperty("descricao").GetString());
+
+                using var motivo = JsonDocument.Parse(reader.GetString(18));
+                Assert.AreEqual("01", motivo.RootElement.GetProperty("codigo").GetString());
+                Assert.AreEqual("Extinção por Encerramento Liquidação Voluntária", motivo.RootElement.GetProperty("descricao").GetString());
+
+                using var pais = JsonDocument.Parse(reader.GetString(19));
+                Assert.AreEqual("105", pais.RootElement.GetProperty("codigo").GetString());
+                Assert.AreEqual("BRASIL", pais.RootElement.GetProperty("descricao").GetString());
+
+                using var qsa = JsonDocument.Parse(reader.GetString(20));
+                Assert.AreEqual(1, qsa.RootElement.GetArrayLength());
+                Assert.AreEqual("249", qsa.RootElement[0].GetProperty("codigo_pais").GetString());
+                Assert.AreEqual("ESTADOS UNIDOS", qsa.RootElement[0].GetProperty("pais").GetProperty("descricao").GetString());
+                Assert.AreEqual("12345678901", qsa.RootElement[0].GetProperty("representante_legal").GetString());
+                Assert.AreEqual("05", qsa.RootElement[0].GetProperty("qualificacao_representante").GetProperty("codigo").GetString());
+
+                Assert.IsFalse(await reader.ReadAsync());
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static async Task SeedReceitaProjectionDataAsync(DuckDBConnection connection, string parquetDir)
+    {
+        await ExecuteAsync(connection, """
+            CREATE TABLE natureza(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO natureza VALUES ('2062', 'Sociedade Empresária Limitada');
+            CREATE TABLE municipio(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO municipio VALUES ('7107', 'SAO PAULO');
+            CREATE TABLE motivo(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO motivo VALUES ('01', 'Extinção por Encerramento Liquidação Voluntária');
+            CREATE TABLE pais(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO pais VALUES ('105', 'BRASIL'), ('249', 'ESTADOS UNIDOS');
+            CREATE TABLE qualificacao(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO qualificacao VALUES ('49', 'Sócio-Administrador'), ('05', 'Administrador'), ('22', 'Sócio');
+            CREATE TABLE cnae(codigo VARCHAR, descricao VARCHAR);
+            INSERT INTO cnae VALUES
+                ('6201501', 'Desenvolvimento de programas de computador sob encomenda'),
+                ('6202300', 'Desenvolvimento e licenciamento de programas de computador customizáveis');
+            """);
+
+        foreach (var tableName in new[] { "natureza", "municipio", "motivo", "pais", "qualificacao", "cnae" })
+            await CopyFlatAsync(connection, parquetDir, tableName);
+
+        await CopyPartitionedAsync(connection, parquetDir, "estabelecimento", """
+            SELECT
+                '607' AS cnpj_prefix,
+                '60701190' AS cnpj_basico,
+                '0001' AS cnpj_ordem,
+                '04' AS cnpj_dv,
+                '1' AS identificador_matriz_filial,
+                'EMPRESA TESTE' AS nome_fantasia,
+                '02' AS situacao_cadastral,
+                '20240115' AS data_situacao_cadastral,
+                '01' AS motivo_situacao_cadastral,
+                'MONTEVIDEO' AS nome_cidade_exterior,
+                '105' AS codigo_pais,
+                '20240115' AS data_inicio_atividade,
+                '6201501' AS cnae_principal,
+                '6202300' AS cnaes_secundarios,
+                'RUA' AS tipo_logradouro,
+                'EXEMPLO' AS logradouro,
+                '100' AS numero,
+                'SALA 01' AS complemento,
+                'CENTRO' AS bairro,
+                '00000000' AS cep,
+                'SP' AS uf,
+                '7107' AS codigo_municipio,
+                '11' AS ddd1,
+                '999999999' AS telefone1,
+                CAST(NULL AS VARCHAR) AS ddd2,
+                CAST(NULL AS VARCHAR) AS telefone2,
+                CAST(NULL AS VARCHAR) AS ddd_fax,
+                CAST(NULL AS VARCHAR) AS fax,
+                'contato@example.invalid' AS correio_eletronico,
+                'BAIXA ESPECIAL' AS situacao_especial,
+                '20250131' AS data_situacao_especial
+            """);
+
+        await CopyPartitionedAsync(connection, parquetDir, "empresa", """
+            SELECT
+                '607' AS cnpj_prefix,
+                '60701190' AS cnpj_basico,
+                'EMPRESA TESTE LTDA' AS razao_social,
+                '2062' AS natureza_juridica,
+                '49' AS qualificacao_responsavel,
+                '10000,00' AS capital_social,
+                '01' AS porte_empresa,
+                'ENTE TESTE' AS ente_federativo
+            """);
+
+        await CopyPartitionedAsync(connection, parquetDir, "simples", """
+            SELECT
+                '607' AS cnpj_prefix,
+                '60701190' AS cnpj_basico,
+                'S' AS opcao_simples,
+                '20240115' AS data_opcao_simples,
+                '20240220' AS data_exclusao_simples,
+                'N' AS opcao_mei,
+                '' AS data_opcao_mei,
+                '20240321' AS data_exclusao_mei
+            """);
+
+        await CopyPartitionedAsync(connection, parquetDir, "socio", """
+            SELECT
+                '607' AS cnpj_prefix,
+                '60701190' AS cnpj_basico,
+                '2' AS identificador_socio,
+                'SOCIO TESTE' AS nome_socio,
+                '***000000**' AS cnpj_cpf_socio,
+                '22' AS qualificacao_socio,
+                '20240115' AS data_entrada_sociedade,
+                '249' AS codigo_pais,
+                '12345678901' AS representante_legal,
+                'REPRESENTANTE TESTE' AS nome_representante,
+                '05' AS qualificacao_representante,
+                '5' AS faixa_etaria
+            """);
+    }
+
+    private static async Task CopyFlatAsync(
+        DuckDBConnection connection,
+        string parquetDir,
+        string tableName)
+    {
+        Directory.CreateDirectory(parquetDir);
+        await ExecuteAsync(connection, $"""
+            COPY {tableName}
+            TO '{EscapeSqlLiteral(Path.Combine(parquetDir, $"{tableName}.parquet"))}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, OVERWRITE)
+            """);
+    }
+
+    private static async Task CopyPartitionedAsync(
+        DuckDBConnection connection,
+        string parquetDir,
+        string tableName,
+        string selectSql)
+    {
+        var tableDir = Path.Combine(parquetDir, tableName);
+        Directory.CreateDirectory(tableDir);
+        await ExecuteAsync(connection, $"""
+            COPY ({selectSql})
+            TO '{EscapeSqlLiteral(tableDir)}'
+            (
+                FORMAT PARQUET,
+                PARTITION_BY (cnpj_prefix)
+            )
+            """);
+    }
+
+    private static async Task ExecuteAsync(DuckDBConnection connection, string sql)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/ETL/Tests/RntrcBigQueryParquetExporterTests.cs
+++ b/src/ETL/Tests/RntrcBigQueryParquetExporterTests.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using CNPJExporter.Modules.Rntrc.Processors;
+using DuckDB.NET.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RntrcBigQueryParquetExporter = CNPJExporter.Modules.Rntrc.BigQueryParquetExporter;
+
+namespace ETL.Tests;
+
+[TestClass]
+public sealed class RntrcBigQueryParquetExporterTests
+{
+    [TestMethod]
+    public async Task MaterializeAsync_ShouldCreateColumnarParquetWithoutPayloadJson()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"opencnpj-rntrc-bigquery-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var csvPath = WriteLatin1Csv(tempRoot, "transportadores_rntrc_03_2026.csv", [
+                "\"Transportadora Ágil LTDA\";\"050085788\";\"23/05/2017\";\"ATIVO\";\"11.193.322/0001-10\";\"ETC\";\"14095-290\";\"RIBEIRÃO PRETO\";\"SP\";\"Sim\";\"23/10/2024\"",
+                "\"+ RAPIDO TRANSPORTADORA LTDA\";\"058308655\";\"23/07/2025\";\"PENDENTE\";\"60.452.651/0001-44\";\"ETC\";\"18120-000\";\"MAIRINQUE\";\"SP\";\"Não\";\"23/07/2025\""
+            ]);
+            var canonicalParquetPath = Path.Combine(tempRoot, "rntrc.parquet");
+
+            await new ParquetProcessor().ConvertToParquetAsync(
+                csvPath,
+                canonicalParquetPath,
+                new DateTimeOffset(2026, 4, 10, 9, 9, 56, TimeSpan.Zero),
+                shardPrefixLength: 3);
+
+            var source = await new RntrcBigQueryParquetExporter(canonicalParquetPath).MaterializeAsync();
+
+            Assert.AreEqual("rntrc", source.TableName);
+            Assert.AreEqual(1, source.SourcePaths.Count);
+            Assert.IsTrue(File.Exists(source.SourcePaths.Single()));
+
+            await using var connection = new DuckDBConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var columnNames = await ReadColumnNamesAsync(connection, source.SourcePaths.Single());
+            Assert.IsFalse(columnNames.Contains("payload_json"), "BigQuery RNTRC não deve carregar payload_json.");
+            CollectionAssert.IsSubsetOf(
+                new[]
+                {
+                    "cnpj",
+                    "cnpj_prefix",
+                    "updated_at",
+                    "numero_rntrc",
+                    "nome",
+                    "categoria",
+                    "situacao",
+                    "data_primeiro_cadastro",
+                    "data_situacao",
+                    "cep",
+                    "municipio",
+                    "uf",
+                    "equiparado"
+                },
+                columnNames.ToArray());
+
+            await using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+                SELECT
+                    cnpj,
+                    cnpj_prefix,
+                    updated_at,
+                    numero_rntrc,
+                    nome,
+                    municipio,
+                    equiparado
+                FROM read_parquet('{EscapeSqlLiteral(source.SourcePaths.Single())}')
+                WHERE cnpj = '11193322000110'";
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("11193322000110", reader.GetString(0));
+            Assert.AreEqual(111, reader.GetInt32(1));
+            Assert.AreEqual("2026-04-10T09:09:56.0000000+00:00", reader.GetString(2));
+            Assert.AreEqual("050085788", reader.GetString(3));
+            Assert.AreEqual("Transportadora Ágil LTDA", reader.GetString(4));
+            Assert.AreEqual("RIBEIRÃO PRETO", reader.GetString(5));
+            Assert.IsTrue(reader.GetBoolean(6));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static async Task<HashSet<string>> ReadColumnNamesAsync(DuckDBConnection connection, string parquetPath)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"SELECT * FROM read_parquet('{EscapeSqlLiteral(parquetPath)}') LIMIT 0";
+        await using var reader = await cmd.ExecuteReaderAsync();
+
+        return Enumerable
+            .Range(0, reader.FieldCount)
+            .Select(reader.GetName)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string WriteLatin1Csv(string directory, string fileName, IReadOnlyList<string> rows)
+    {
+        var path = Path.Combine(directory, fileName);
+        var header = "nome_transportador;numero_rntrc;data_primeiro_cadastro;situacao_rntrc;cpfcnpjtransportador;categoria_transportador;cep;municipio;uf;equiparado;data_situacao_rntrc";
+        File.WriteAllText(path, string.Join("\r\n", [header, .. rows]), Encoding.Latin1);
+        return path;
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''");
+}

--- a/src/Page/src/pages/AnalyticsPage.tsx
+++ b/src/Page/src/pages/AnalyticsPage.tsx
@@ -1,8 +1,10 @@
 import { CodeBlock } from '../components/CodeBlock';
 import { SectionHeading } from '../components/SectionHeading';
 
-const BIGQUERY_TABLE = 'opencnpj-bigquery.public.empresas';
-const BIGQUERY_SQL_TABLE = `\`${BIGQUERY_TABLE}\``;
+const BIGQUERY_RECEITA_TABLE = 'opencnpj-bigquery.public.receita';
+const BIGQUERY_CNO_TABLE = 'opencnpj-bigquery.public.cno';
+const BIGQUERY_RNTRC_TABLE = 'opencnpj-bigquery.public.rntrc';
+const BIGQUERY_RECEITA_SQL_TABLE = `\`${BIGQUERY_RECEITA_TABLE}\``;
 
 export function AnalyticsPage() {
   return (
@@ -14,8 +16,14 @@ export function AnalyticsPage() {
 
       <p>
         A API é indicada para consulta pontual por CNPJ. Para análises exploratórias, enriquecimento batch e relatórios,
-        use a tabela pública do OpenCNPJ no BigQuery: <code>{BIGQUERY_TABLE}</code>.
+        use as tabelas públicas do OpenCNPJ no BigQuery.
       </p>
+
+      <ul>
+        <li><code>{BIGQUERY_RECEITA_TABLE}</code> para Receita Federal.</li>
+        <li><code>{BIGQUERY_CNO_TABLE}</code> para Cadastro Nacional de Obras.</li>
+        <li><code>{BIGQUERY_RNTRC_TABLE}</code> para RNTRC.</li>
+      </ul>
 
       <div className="actions">
         <a className="btn primary" href="https://bigquery.opencnpj.org" target="_blank" rel="noopener">Abrir no BigQuery</a>
@@ -39,7 +47,7 @@ export function AnalyticsPage() {
   uf,
   municipio,
   cnae_principal
-FROM ${BIGQUERY_SQL_TABLE}
+FROM ${BIGQUERY_RECEITA_SQL_TABLE}
 WHERE cnpj = '12ABC34501DE35'
 LIMIT 1;`} />
 
@@ -47,8 +55,8 @@ LIMIT 1;`} />
       <CodeBlock language="sql" code={`SELECT
   uf,
   COUNT(*) AS total_empresas
-FROM ${BIGQUERY_SQL_TABLE}
-WHERE situacao_cadastral = 'ATIVA'
+FROM ${BIGQUERY_RECEITA_SQL_TABLE}
+WHERE situacao_cadastral = 'Ativa'
 GROUP BY uf
 ORDER BY total_empresas DESC;`} />
 
@@ -62,13 +70,13 @@ ORDER BY total_empresas DESC;`} />
 )
 SELECT
   base.cnpj,
-  empresas.razao_social,
-  empresas.situacao_cadastral,
-  empresas.uf,
-  empresas.municipio
+  receita.razao_social,
+  receita.situacao_cadastral,
+  receita.uf,
+  receita.municipio
 FROM minha_base AS base
-LEFT JOIN ${BIGQUERY_SQL_TABLE} AS empresas
-  ON empresas.cnpj = base.cnpj;`} />
+LEFT JOIN ${BIGQUERY_RECEITA_SQL_TABLE} AS receita
+  ON receita.cnpj = base.cnpj;`} />
 
       <h2>Boas práticas</h2>
       <ul>

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -146,6 +146,79 @@ read_config_value() {
   ' "$ETL_CONFIG" "$expression"
 }
 
+read_bigquery_enabled() {
+  if [[ -n "${OPENCNPJ_BIGQUERY_ENABLED:-}" ]]; then
+    case "${OPENCNPJ_BIGQUERY_ENABLED,,}" in
+      true)
+        printf 'true\n'
+        return 0
+        ;;
+      false)
+        printf 'false\n'
+        return 0
+        ;;
+      *)
+        echo "OPENCNPJ_BIGQUERY_ENABLED deve ser true ou false." >&2
+        exit 1
+        ;;
+    esac
+  fi
+
+  read_config_value "BigQuery.Enabled"
+}
+
+read_bigquery_project_id() {
+  if [[ -n "${OPENCNPJ_BIGQUERY_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OPENCNPJ_BIGQUERY_PROJECT_ID"
+    return 0
+  fi
+
+  read_config_value "BigQuery.ProjectId"
+}
+
+require_bigquery_command_if_enabled() {
+  local enabled
+  enabled="$(read_bigquery_enabled 2>/dev/null || printf 'false')"
+  if [[ "$enabled" != "true" ]]; then
+    log "BigQuery não habilitado; publicação/atualização de tabelas será ignorada."
+    return 0
+  fi
+
+  local executable
+  executable="$(read_config_value "BigQuery.BqExecutable" 2>/dev/null || printf 'bq')"
+  if [[ -z "$executable" ]]; then
+    executable="bq"
+  fi
+
+  local project_id
+  local dataset
+  local location
+  project_id="$(read_bigquery_project_id 2>/dev/null || true)"
+  dataset="$(read_config_value "BigQuery.Dataset" 2>/dev/null || true)"
+  location="$(read_config_value "BigQuery.Location" 2>/dev/null || true)"
+  if [[ -z "$project_id" ]]; then
+    echo "BigQuery.ProjectId ou OPENCNPJ_BIGQUERY_PROJECT_ID é obrigatório quando BigQuery.Enabled=true." >&2
+    exit 1
+  fi
+  if [[ -z "$dataset" ]]; then
+    echo "BigQuery.Dataset é obrigatório quando BigQuery.Enabled=true." >&2
+    exit 1
+  fi
+
+  require_command "$executable"
+
+  local bq_args=()
+  if [[ -n "$location" ]]; then
+    bq_args+=("--location=${location}")
+  fi
+
+  log "Validando BigQuery em ${project_id}:${dataset}"
+  if ! "$executable" "${bq_args[@]}" show --format=none "${project_id}:${dataset}" >/dev/null 2>&1; then
+    echo "Não foi possível validar BigQuery em ${project_id}:${dataset}. Verifique autenticação, permissões e existência do dataset." >&2
+    exit 1
+  fi
+}
+
 json_field() {
   local payload="$1"
   local field="$2"
@@ -498,6 +571,8 @@ capture_current_info() {
     return 0
   fi
 }
+
+require_bigquery_command_if_enabled
 
 if [[ -z "$RELEASE_ID" ]]; then
   RELEASE_ID="$(generate_release_id)"

--- a/src/scripts/docker-entrypoint.sh
+++ b/src/scripts/docker-entrypoint.sh
@@ -33,11 +33,52 @@ require_file() {
   fi
 }
 
-read_remote_name() {
+read_config_value() {
+  local expression="$1"
   node -e '
     const fs = require("node:fs");
     const config = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-    const remoteBase = config?.Rclone?.RemoteBase;
+    const expression = process.argv[2].split(".");
+    let current = config;
+    for (const part of expression) current = current?.[part];
+    if (current == null) process.exit(2);
+    process.stdout.write(String(current));
+  ' "$ETL_CONFIG" "$expression"
+}
+
+read_bigquery_enabled() {
+  if [[ -n "${OPENCNPJ_BIGQUERY_ENABLED:-}" ]]; then
+    case "${OPENCNPJ_BIGQUERY_ENABLED,,}" in
+      true)
+        printf 'true\n'
+        return 0
+        ;;
+      false)
+        printf 'false\n'
+        return 0
+        ;;
+      *)
+        echo "OPENCNPJ_BIGQUERY_ENABLED deve ser true ou false." >&2
+        exit 1
+        ;;
+    esac
+  fi
+
+  read_config_value "BigQuery.Enabled"
+}
+
+read_bigquery_project_id() {
+  if [[ -n "${OPENCNPJ_BIGQUERY_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OPENCNPJ_BIGQUERY_PROJECT_ID"
+    return 0
+  fi
+
+  read_config_value "BigQuery.ProjectId"
+}
+
+read_remote_name() {
+  node -e '
+    const remoteBase = process.argv[1];
     if (typeof remoteBase !== "string" || remoteBase.length === 0) {
       process.exit(1);
     }
@@ -48,7 +89,7 @@ read_remote_name() {
     }
 
     process.stdout.write(remoteBase.slice(0, separator));
-  ' "$ETL_CONFIG"
+  ' "$(read_config_value "Rclone.RemoteBase")"
 }
 
 require_rclone_remote() {
@@ -65,6 +106,43 @@ require_rclone_remote() {
     echo "Remote obrigatório do rclone não encontrado: ${remote_label}" >&2
     exit 1
   fi
+}
+
+activate_bigquery_credentials_if_configured() {
+  local enabled
+  enabled="$(read_bigquery_enabled 2>/dev/null || printf 'false')"
+  if [[ "$enabled" != "true" ]]; then
+    return 0
+  fi
+
+  if [[ -z "${OPENCNPJ_GOOGLE_CREDENTIALS_BASE64:-}" ]]; then
+    log "OPENCNPJ_GOOGLE_CREDENTIALS_BASE64 não configurado; usando credenciais já disponíveis para o bq."
+    return 0
+  fi
+
+  local project_id
+  project_id="$(read_bigquery_project_id 2>/dev/null || true)"
+  if [[ -z "$project_id" ]]; then
+    echo "BigQuery.ProjectId ou OPENCNPJ_BIGQUERY_PROJECT_ID é obrigatório quando BigQuery.Enabled=true." >&2
+    exit 1
+  fi
+
+  require_command gcloud
+  TMP_GOOGLE_CREDENTIALS="$(mktemp /tmp/google-credentials.XXXXXX.json)"
+  if ! printf '%s' "$OPENCNPJ_GOOGLE_CREDENTIALS_BASE64" | base64 -d > "$TMP_GOOGLE_CREDENTIALS" 2>/dev/null; then
+    echo "OPENCNPJ_GOOGLE_CREDENTIALS_BASE64 inválido; não foi possível decodificar a credencial Google." >&2
+    exit 1
+  fi
+
+  chmod 600 "$TMP_GOOGLE_CREDENTIALS"
+  export CLOUDSDK_CORE_DISABLE_PROMPTS="${CLOUDSDK_CORE_DISABLE_PROMPTS:-1}"
+  gcloud auth activate-service-account \
+    --key-file="$TMP_GOOGLE_CREDENTIALS" \
+    --project="$project_id" \
+    --quiet >/dev/null
+  rm -f "$TMP_GOOGLE_CREDENTIALS"
+  TMP_GOOGLE_CREDENTIALS=""
+  log "Credenciais BigQuery ativadas via OPENCNPJ_GOOGLE_CREDENTIALS_BASE64"
 }
 
 if ! [[ "$CHECK_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || [[ "$CHECK_INTERVAL_SECONDS" -le 0 ]]; then
@@ -93,9 +171,13 @@ fi
 require_env CLOUDFLARE_API_TOKEN
 
 TMP_RCLONE_CONFIG=""
+TMP_GOOGLE_CREDENTIALS=""
 cleanup() {
   if [[ -n "$TMP_RCLONE_CONFIG" && -f "$TMP_RCLONE_CONFIG" ]]; then
     rm -f "$TMP_RCLONE_CONFIG"
+  fi
+  if [[ -n "$TMP_GOOGLE_CREDENTIALS" && -f "$TMP_GOOGLE_CREDENTIALS" ]]; then
+    rm -f "$TMP_GOOGLE_CREDENTIALS"
   fi
 }
 trap cleanup EXIT
@@ -117,6 +199,7 @@ fi
 
 RCLONE_REMOTE_NAME="$(read_remote_name)"
 require_rclone_remote "$RCLONE_REMOTE_NAME"
+activate_bigquery_credentials_if_configured
 
 if [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
   log "CLOUDFLARE_ACCOUNT_ID configurado"


### PR DESCRIPTION
## Summary

- Add BigQuery publication planning/loading with staging tables and explicit project/dataset validation.
- Generate columnar BigQuery Parquet sources for Receita, CNO, and RNTRC instead of loading JSON payload envelopes.
- Update deploy/runtime BigQuery configuration, credential activation, docs, and the Consultas Analíticas page to reference the new public tables.

## Root Cause

The Receita table initially drifted between JSON-envelope and legacy-column shapes, while CNO/RNTRC were still being loaded from the generic integration Parquet contract (`payload_json`). That contract is correct for API shards and incremental hashing, but wrong for public analytical BigQuery tables.

## Validation

- `git diff --check`
- `dotnet test src/ETL/OpenCNPJ.sln` — 78 passed, 6 skipped
- `npm ci` in `src/Page`
- `npm run build` in `src/Page`

## Notes

- The runtime secrets remain environment-provided; no credential values are committed.
- The PR is draft so the final BigQuery/Dokploy run can be reviewed before merge.